### PR TITLE
NXPY-30: Adapt the test

### DIFF
--- a/nuxeo/nuxeo.py
+++ b/nuxeo/nuxeo.py
@@ -715,7 +715,8 @@ class Nuxeo(object):
 
     def drive_config(self):
         """
-        Fetch the Drive configuration file at $NUXEO_URL/api/v1/drive/configuration.
+        Fetch the Drive JSON configuration from
+        the $NUXEO_URL/api/v1/drive/configuration endpoint.
         """
 
         url = self._rest_url + 'drive/configuration'

--- a/tests/test_nuxeo.py
+++ b/tests/test_nuxeo.py
@@ -70,13 +70,14 @@ def test_drive_config(monkeypatch):
 
     config = nuxeo.drive_config()
     assert isinstance(config, dict)
-    assert 'beta_channel' in config
-    assert 'delay' in config
-    assert 'handshake_timeout' in config
-    assert 'log_level_file' in config
-    assert 'timeout' in config
-    assert 'update_check_delay' in config
-    assert 'ui' in config
+    if config:
+        assert 'beta_channel' in config
+        assert 'delay' in config
+        assert 'handshake_timeout' in config
+        assert 'log_level_file' in config
+        assert 'timeout' in config
+        assert 'update_check_delay' in config
+        assert 'ui' in config
 
     monkeypatch.setattr(nuxeo.opener, 'open', mock_server_error)
     assert not nuxeo.drive_config()


### PR DESCRIPTION
Only test the keys of the dict if the dict returned by the server is not empty.
Also updating the docstring of the function.