### PR TITLE
NXDRIVE-26: Fix and tweaks for setup.cfg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Release date: ``2017-??-??``
 -  `NXPY-14 <https://jira.nuxeo.com/browse/NXPY-14>`__: Quote Repository URLs
 -  `NXPY-22 <https://jira.nuxeo.com/browse/NXPY-22>`__: Sanitize relative URLs
 -  `NXPY-25 <https://jira.nuxeo.com/browse/NXPY-25>`__: Allow strings as properties
+-  `NXPY-27 <https://jira.nuxeo.com/browse/NXPY-27>`__: Use of setup.cfg
 -  `NXPY-29 <https://jira.nuxeo.com/browse/NXPY-29>`__: Fix an encoding error in ``Nuxeo._log_details()``
 -  A lot of code clean-up and improvement
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2016 Nuxeo SA (http://nuxeo.com/) and others.
+Copyright Nuxeo (http://nuxeo.com/) and others.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.rst
+++ b/README.rst
@@ -11,12 +11,11 @@ This is an on-going project, supported by Nuxeo.
 Getting Started
 ---------------
 
-After installing `Python <https://www.python.org/downloads/>`__, use
-``pip`` to install the ``nuxeo-python-client`` package:
+The installation is as simple as:
 
 ::
 
-    $ pip install --upgrade nuxeo-python-client
+    $ pip install --upgrade nuxeo
 
 Then, use the following ``import`` statement to have access to the Nuxeo
 API:
@@ -28,8 +27,7 @@ API:
 Documentation
 -------------
 
-Check out the `API
-documentation <https://nuxeo.github.io/nuxeo-python-client/latest/>`__.
+Check out the `API documentation <https://nuxeo.github.io/nuxeo-python-client/latest/>`__.
 
 Requirements
 ------------
@@ -453,28 +451,23 @@ Requirements
 Setup
 ~~~~~
 
-Install `Python <https://www.python.org/downloads/>`__ and then use
-``pip`` to install all the required libraries:
-
 ::
 
     $ git clone https://github.com/nuxeo/nuxeo-python-client
     $ cd nuxeo-python-client
-    $ pip install -r requirements.txt
+    $ python setup.py develop
 
 Test
 ~~~~
 
 A Nuxeo Platform instance needs to be running on
-``http://localhost:8080/nuxeo`` for the tests to be run.
-
-Tests can be launched on Python Nosetests with:
+``http://localhost:8080/nuxeo`` for the tests to be run, and then:
 
 ::
 
-    $ nosetests -v
+    $ python setup.py test
 
-Tests can be launched without a server with Maven and Nosetests:
+Tests can be launched without a server with Maven and pytest:
 
 ::
 

--- a/nuxeo/__init__.py
+++ b/nuxeo/__init__.py
@@ -9,21 +9,32 @@ If that URL should fail, try contacting the author.
 
 Contributors:
     Antoine Taillefer <ataillefer@nuxeo.com>
-    Rémi Cattiau <rcattiau@nuxeo.com>
+    Rémi Cattiau
     Mickaël Schoentgen <mschoentgen@nuxeo.com>
     Léa Klein <lklein@nuxeo.com>
-    https://github.com/nuxeo/nuxeo-python-client/graphs/contributors
+    and https://github.com/nuxeo/nuxeo-python-client/graphs/contributors
 """
 from __future__ import unicode_literals
 
-from .nuxeo import Nuxeo
 from os import path
+
+import pkg_resources
 from setuptools.config import read_configuration
 
-_conf = read_configuration(path.join(path.dirname(path.dirname(__file__)), 'setup.cfg'))
+from .nuxeo import Nuxeo
 
-__author__ = _conf['metadata']['author']
-__version__ = _conf['metadata']['version']
+
+def _extract_version():
+    try:
+        return pkg_resources.get_distribution('nuxeo').version
+    except pkg_resources.DistributionNotFound:
+        _conf = read_configuration(path.join(
+            path.dirname(path.dirname(__file__)), 'setup.cfg'))
+        return _conf['metadata']['version']
+
+
+__author__ = 'Nuxeo'
+__version__ = _extract_version()
 __copyright__ = """
     Copyright Nuxeo (https://www.nuxeo.com) and others.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,22 +6,36 @@ author-email = maintainers-python@nuxeo.com
 description = Nuxeo REST API Python client
 long_description = file: README.rst
 url = https://github.com/nuxeo/nuxeo-python-client
+home-page = https://www.nuxeo.com/products/drive-desktop-sync/
 keywords = api, rest, automation, client, nuxeo, ecm
 license = Apache Software
+license_file = LICENSE.txt
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
+    Natural Language :: English
     Operating System :: OS Independent
-    Programming Language :: Python
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Topic :: Software Development :: Libraries
 
-[files]
+[options]
+zip-safe = False
 include_package_data = True
 packages = nuxeo
-
-[options]
 install_requires = poster
+setup_requires = pytest-runner
 tests_require = pytest
+
+[options.package_data]
+* = *.cfg, *.rst, *.txt
+
+[bdist_wheel]
+universal = 1
+
+[aliases]
+test = pytest
+
+[tool:pytest]
+addopts = --showlocals --failed-first

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # coding: utf-8
 from setuptools import setup
 
+
 setup()


### PR DESCRIPTION
We can now launch tests using `python setup.py test`.
Also:
  - A fix with the version lookup