### PR TITLE
NXPY-9: Python 3 support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,9 @@ Technical changes
 -  Added ``Document.is_locked()``
 -  Removed ``FileBlob.get_upload_buffer()``
 -  Removed ``FileBlob._read_data()``
+-  Added nuxeo/compat.py::\ ``get_bytes()``
+-  Added nuxeo/compat.py::\ ``get_error_message()``
+-  Added nuxeo/compat.py::\ ``get_text()``
 -  Removed ``Nuxeo.Request``
 -  Moved ``Nuxeo.InvalidBatchException`` to
    nuxeo/exceptions.py::\ ``InvalidBatchException``

--- a/examples/find_duplicates.py
+++ b/examples/find_duplicates.py
@@ -23,15 +23,17 @@ Example output:
     707e6ea7-a7c1-49aa-b3bd-764d27e6f3ef
     54969ca5-0be2-4bbf-938a-3e8b4016e420
 """
-
+from __future__ import unicode_literals
 import argparse
 import os
 import re
-import urllib
 from collections import defaultdict
-from urllib2 import HTTPError
 
-from nuxeo import Nuxeo
+from future.utils import iteritems
+from requests import HTTPError
+
+from nuxeo.compat import quote, get_bytes
+from nuxeo.nuxeo import Nuxeo
 
 
 class BColors(object):
@@ -46,7 +48,7 @@ class BColors(object):
 
 
 base_url = os.environ.get('NXDRIVE_TEST_SERVER_URL',
-                          'http://localhost:8080/nuxeo'),
+                          'http://localhost:8080/nuxeo')
 auth = {
     'username': os.environ.get('NXDRIVE_TEST_USER', 'Administrator'),
     'password': os.environ.get('NXDRIVE_TEST_PASSWORD', 'Administrator'),
@@ -61,16 +63,12 @@ def color_print(text, color):
 
 def print_duplicates(path, uids):
     print('{}\'{}\'{} appears {} times with following uids:\n{}'.format(
-        BColors.OKBLUE, path, BColors.ENDC, len(uids), unicode_join(uids, '\n')))
-
-
-def unicode_join(array, spacer=''):
-    return spacer.join([x.encode('utf-8') for x in array])
+        BColors.OKBLUE, path, BColors.ENDC, len(uids), '\n'.join(uids)))
 
 
 def compute_uid_line(item):
     if item['state'] == 'deleted':
-        return unicode_join([item['uid'], ' (deleted)'])
+        return ''.join([item['uid'], ' (deleted)'])
     else:
         return item['uid']
 
@@ -87,9 +85,9 @@ def find_duplicates_in_folder(folder):
         else:
             doc_names[doc['title']].append(compute_uid_line(doc))
 
-    for name, uids in doc_names.iteritems():
+    for (name, uids) in iteritems(doc_names):
         if len(uids) > 1:
-            print_duplicates(unicode_join([folder, name]), uids)
+            print_duplicates('/'.join([folder, name]), uids)
 
 
 def find_duplicates_of_uid(uid):
@@ -100,15 +98,15 @@ def find_duplicates_of_uid(uid):
             doc = nuxeo.repository().fetch(uid)
             query = "SELECT * FROM Document WHERE ecm:parentId = '" + doc.parentRef + "'"
             query += " AND dc:title = '" + doc.title + "'"
-            request = 'query?query=' + urllib.quote(query.encode('utf-8'), safe='!=:')
+            request = 'query?query=' + quote(get_bytes(query), safe='!=:')
             entries = nuxeo.request(request).get('entries')
             if len(entries) > 1:
-                print_duplicates(unicode_join([doc.path.rsplit('/', 1)[0], doc.title], '/'),
+                print_duplicates('/'.join([doc.path.rsplit('/', 1)[0], doc.title]),
                                  [compute_uid_line(x) for x in entries])
             else:
                 color_print('No duplicate for the document with uid={}.'.format(uid), BColors.OKGREEN)
         except HTTPError as e:
-            if e.code == 404:
+            if e.response.status_code == 404:
                 color_print('No document with uid={}.'.format(uid), BColors.FAIL)
 
 
@@ -121,12 +119,12 @@ def find_duplicates_with_name(name):
         doc_paths[doc['path'].rsplit('/', 1)[0]].append(compute_uid_line(doc))
 
     no_duplicates = True
-    for path, uids in doc_paths.iteritems():
+    for (path, uids) in iteritems(doc_paths):
         if len(uids) > 1:
             no_duplicates = False
-            print_duplicates(unicode_join([path, name]), uids)
+            print_duplicates('/'.join([path, name]), uids)
     if no_duplicates:
-        color_print('No duplicate for {}.'.format(name.encode('utf-8')), BColors.OKGREEN)
+        color_print('No duplicate for {}.'.format(get_bytes(name)), BColors.OKGREEN)
 
 
 def main():

--- a/examples/find_duplicates.py
+++ b/examples/find_duplicates.py
@@ -24,12 +24,12 @@ Example output:
     54969ca5-0be2-4bbf-938a-3e8b4016e420
 """
 from __future__ import unicode_literals
+
 import argparse
 import os
 import re
 from collections import defaultdict
 
-from future.utils import iteritems
 from requests import HTTPError
 
 from nuxeo.compat import quote, get_bytes
@@ -85,7 +85,7 @@ def find_duplicates_in_folder(folder):
         else:
             doc_names[doc['title']].append(compute_uid_line(doc))
 
-    for (name, uids) in iteritems(doc_names):
+    for (name, uids) in doc_names.items():
         if len(uids) > 1:
             print_duplicates('/'.join([folder, name]), uids)
 
@@ -119,7 +119,7 @@ def find_duplicates_with_name(name):
         doc_paths[doc['path'].rsplit('/', 1)[0]].append(compute_uid_line(doc))
 
     no_duplicates = True
-    for (path, uids) in iteritems(doc_paths):
+    for (path, uids) in doc_paths.items():
         if len(uids) > 1:
             no_duplicates = False
             print_duplicates('/'.join([path, name]), uids)

--- a/nuxeo/batchupload.py
+++ b/nuxeo/batchupload.py
@@ -2,9 +2,9 @@
 from __future__ import unicode_literals
 
 import re
-import urllib2
 
 from .blob import Blob, BlobInfo, FileBlob
+from .compat import get_bytes, get_text, quote, text
 from .exceptions import InvalidBatchException
 
 try:
@@ -54,7 +54,7 @@ class BatchUpload(object):
         """
         if self.batchid is None:
             raise InvalidBatchException('Cannot fetch blob for inexistant/deleted batch.')
-        path = self._get_path() + '/' + str(index)
+        path = self._get_path() + '/' + text(index)
         res = self._nuxeo.request(path)
         res['fileIdx'] = index
         return BlobInfo(self, res)
@@ -75,14 +75,14 @@ class BatchUpload(object):
         if self.batchid is None:
             self.batchid = self._create_batchid()
         filename = safe_filename(blob.get_name())
-        quoted_filename = urllib2.quote(filename.encode('utf-8'))
-        path = self._get_path() + '/' + str(self._upload_index)
+        quoted_filename = quote(get_text(filename))
+        path = self._get_path() + '/' + text(self._upload_index)
         headers = {
             'Cache-Control': 'no-cache',
             'X-File-Name': quoted_filename,
-            'X-File-Size': str(blob.get_size()),
+            'X-File-Size': text(blob.get_size()),
             'X-File-Type': blob.get_mimetype(),
-            'Content-Length': str(blob.get_size()),
+            'Content-Length': text(blob.get_size()),
         }
         data = blob.get_data()
         try:

--- a/nuxeo/batchupload.py
+++ b/nuxeo/batchupload.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import re
 
 from .blob import Blob, BlobInfo, FileBlob
-from .compat import get_bytes, get_text, quote, text
+from .compat import get_text, quote, text
 from .exceptions import InvalidBatchException
 
 try:

--- a/nuxeo/blob.py
+++ b/nuxeo/blob.py
@@ -6,6 +6,8 @@ import os
 import sys
 from io import StringIO
 
+from .compat import text
+
 try:
     from typing import Any, Dict, IO, Optional, Text, Union
 except ImportError:
@@ -96,7 +98,7 @@ class BlobInfo(object):
         # type: () -> Dict[Text, Text]
         return {
             'upload-batch': self.get_batch_id(),
-            'upload-fileId': str(self.fileIdx).decode('utf-8'),
+            'upload-fileId': text(self.fileIdx),
         }
 
 

--- a/nuxeo/common.py
+++ b/nuxeo/common.py
@@ -30,9 +30,9 @@ class NuxeoObject(object):
 
     def __repr__(self):
         # type: () -> Text
-        ret = ', '.join('{}={!r}'.format(*item) for item in vars(self).items()
-                        if not item[0].startswith('_'))
-        return u'<{}({})>'.format(type(self).__name__, ret)
+        ret = ', '.join('{}={!r}'.format(key, value) for (key, value) in vars(self).items()
+                        if not key.startswith('_'))
+        return '<{} ({})>'.format(type(self).__name__, ret)
 
     def delete(self):
         # type: () -> None
@@ -69,14 +69,15 @@ class NuxeoAutosetObject(NuxeoObject):
 
     def __getattr__(self, item):
         # type: (str) -> Text
-        if hasattr(self, item) or item.startswith('_'):
-            return super(NuxeoObject, self).__getattribute__(item)
         if self._lazy:
             raise RuntimeError(
                 'Lazy loading is not yet implemented - use load()')
-        if self._autoset and item in self.properties:
-            return self.properties[item]
-        raise AttributeError
+        try:
+            return super(NuxeoObject, self).__getattribute__(item)
+        except AttributeError:
+            if self._autoset and item in self.properties:
+                return self.properties[item]
+            raise
 
     def __setattr__(self, name, value):
         # type: (str, Any) -> None

--- a/nuxeo/compat.py
+++ b/nuxeo/compat.py
@@ -1,0 +1,63 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+try:
+    from typing import Text, Union
+    from requests import HTTPError
+except ImportError:
+    pass
+
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib2 import quote
+
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
+
+try:
+    text = unicode
+except NameError:
+    text = str
+
+
+def get_bytes(data):
+    # type: (Union[Text, bytes]) -> bytes
+    """
+    If data is not bytes, encode it.
+
+    :param data: the input data
+    :return: the bytes of data
+    """
+    if isinstance(data, text):
+        data = data.encode('utf-8')
+    return data
+
+
+def get_text(data):
+    # type: (Union[Text, bytes]) -> Text
+    """
+    If data is not text, decode it.
+
+    :param data: the input data
+    :return: data in unicode
+    """
+    if not isinstance(data, text):
+        data = data.decode('utf-8')
+    return data
+
+
+def get_error_message(e):
+    # type: (HTTPError) -> Text
+    """
+    Get error message from an HTTPError.
+
+    :param e: the HTTPError
+    :return: The text of the message
+    """
+    if hasattr(e, 'message'):
+        return get_text(e.message)
+    else:
+        return get_text(e.args[0])

--- a/nuxeo/exceptions.py
+++ b/nuxeo/exceptions.py
@@ -1,6 +1,9 @@
 # coding: utf-8
+from __future__ import unicode_literals
 
 from requests import HTTPError
+
+from .compat import text
 
 try:
     from typing import Any, Dict, Optional, Text
@@ -30,12 +33,12 @@ class Unauthorized(HTTPError):
         if http_error:
             self.__dict__.update(http_error.__dict__)
         self.user_id = user_id
-        self.message = str(self)
+        self.message = text(self)
 
     def __str__(self):
         # type: () -> Text
         return '\'{!s}\' is not authorized to access {!s} with the provided credentials'.format(
-            self.user_id.encode('utf-8'), self.response.url)
+            self.user_id, self.response.url)
 
 
 class UnavailableConvertor(Exception):
@@ -48,7 +51,7 @@ class UnavailableConvertor(Exception):
     def __init__(self, options):
         # type: (Dict[Text, Any]) -> None
         self.options = options
-        self.message = str(self)
+        self.message = text(self)
 
     def __str__(self):
         # type: () -> Text

--- a/nuxeo/nuxeo.py
+++ b/nuxeo/nuxeo.py
@@ -10,7 +10,6 @@ import tempfile
 from collections import Sequence
 
 import requests
-from future.utils import iteritems
 from requests import HTTPError
 from requests.cookies import RequestsCookieJar
 
@@ -164,7 +163,7 @@ class Nuxeo(object):
 
         parameters = {param['name']: param for param in operation['params']}
 
-        for (name, value) in iteritems(params):
+        for (name, value) in params.items():
             # Check for unexpected parameters.  We use `dict.pop()` to
             # get and delete the parameter from the dict.
             try:
@@ -182,7 +181,7 @@ class Nuxeo(object):
 
         # Check for required parameters.  As of now, `parameters` may contain
         # unclaimed parameters and we just need to check for required ones.
-        for (name, parameter) in iteritems(parameters):
+        for (name, parameter) in parameters.items():
             if parameter['required']:
                 err = 'missing required parameter {!r} for operation {!r}'
                 raise ValueError(err.format(name, command))
@@ -257,12 +256,12 @@ class Nuxeo(object):
             headers.update(extra_headers)
 
         json_struct = {'params': {}}
-        for (k, v) in iteritems(params):
+        for (k, v) in params.items():
             if v is None:
                 continue
             if k == 'properties':
                 if isinstance(v, dict):
-                    s = '\n'.join(['{}={}'.format(name, value) for (name, value) in iteritems(v)])
+                    s = '\n'.join(['{}={}'.format(name, value) for (name, value) in v.items()])
                 else:
                     s = v
                 json_struct['params'][k] = s.strip()
@@ -589,7 +588,7 @@ class Nuxeo(object):
         if isinstance(e, HTTPError):
             msg = get_error_message(e)
 
-            logger.exception(u'Remote exception: {}'.format(msg))
+            logger.exception('Remote exception: {}'.format(msg))
             try:
                 exc = e.response.json()
                 message = exc.get('message')

--- a/nuxeo/nuxeo.py
+++ b/nuxeo/nuxeo.py
@@ -2,20 +2,21 @@
 """ Nuxeo REST API Client. """
 from __future__ import unicode_literals
 
+import base64
 import json
 import logging
 import socket
-from urllib import urlencode
-
-import base64
-import requests
 import tempfile
 from collections import Sequence
+
+import requests
+from future.utils import iteritems
 from requests import HTTPError
 from requests.cookies import RequestsCookieJar
 
 from .batchupload import BatchUpload
 from .blob import Blob
+from .compat import text, urlencode, get_bytes, get_text, get_error_message
 from .directory import Directory
 from .exceptions import Unauthorized
 from .groups import Groups
@@ -33,26 +34,27 @@ __all__ = ('Nuxeo',)
 
 logger = logging.getLogger(__name__)
 
+
 CHUNK_SIZE = 8192  # Chunk size to download files
 
 PARAM_TYPES = {  # Types allowed for operations parameters
-    'blob': (unicode, Blob),
+    'blob': (text, Blob),
     'boolean': (bool,),
-    'date': (unicode,),
-    'document': (unicode,),
+    'date': (text,),
+    'document': (text,),
     'documents': (list,),
     'int': (int,),
     'integer': (int,),
-    'long': (int, long),
+    'long': (int,),
     'map': (dict,),
     'object': (object,),
     'properties': (dict,),
-    'resource': (unicode,),
+    'resource': (text,),
     'serializable': (Sequence,),
-    'string': (unicode,),
+    'string': (text,),
     'stringlist': (Sequence,),
-    'validationmethod': (unicode,),
-}  # type: Dict[unicode, Tuple[type, ...]])
+    'validationmethod': (text,),
+}  # type = Dict[Text, Tuple[type, ...]])
 
 
 def json_helper(o):
@@ -162,7 +164,7 @@ class Nuxeo(object):
 
         parameters = {param['name']: param for param in operation['params']}
 
-        for name, value in params.iteritems():
+        for (name, value) in iteritems(params):
             # Check for unexpected parameters.  We use `dict.pop()` to
             # get and delete the parameter from the dict.
             try:
@@ -180,7 +182,7 @@ class Nuxeo(object):
 
         # Check for required parameters.  As of now, `parameters` may contain
         # unclaimed parameters and we just need to check for required ones.
-        for name, parameter in parameters.iteritems():
+        for (name, parameter) in iteritems(parameters):
             if parameter['required']:
                 err = 'missing required parameter {!r} for operation {!r}'
                 raise ValueError(err.format(name, command))
@@ -255,12 +257,12 @@ class Nuxeo(object):
             headers.update(extra_headers)
 
         json_struct = {'params': {}}
-        for k, v in params.iteritems():
+        for (k, v) in iteritems(params):
             if v is None:
                 continue
             if k == 'properties':
                 if isinstance(v, dict):
-                    s = '\n'.join(['{}={}'.format(name, value) for name, value in v.iteritems()])
+                    s = '\n'.join(['{}={}'.format(name, value) for (name, value) in iteritems(v)])
                 else:
                     s = v
                 json_struct['params'][k] = s.strip()
@@ -457,7 +459,7 @@ class Nuxeo(object):
             'deviceId': device_id,
             'applicationName': application_name,
             'permission': permission,
-            'revoke': str(revoke).lower(),
+            'revoke': text(revoke).lower(),
         }
         if device_description:
             parameters['deviceDescription'] = device_description
@@ -585,8 +587,9 @@ class Nuxeo(object):
     def _log_details(self, e):
         # type: (Exception) -> None
         if isinstance(e, HTTPError):
-            logger.exception(u'Remote exception: {}'.format(
-                e.message.decode('utf-8')))
+            msg = get_error_message(e)
+
+            logger.exception(u'Remote exception: {}'.format(msg))
             try:
                 exc = e.response.json()
                 message = exc.get('message')
@@ -623,8 +626,12 @@ class Nuxeo(object):
         if token:
             self._auth = {'X-Authentication-Token': token}
         elif password:
-            self._auth = {'Authorization': 'Basic {}'.format(
-                base64.b64encode('{}:{}'.format(
-                    self.user_id, password).encode('utf-8')).strip())}
+            credentials = '{}:{}'.format(self.user_id, password)
+            if isinstance(credentials, text):
+                credentials = get_bytes(credentials)
+
+            b64 = get_text(base64.b64encode(credentials))
+
+            self._auth = {'Authorization': 'Basic {}'.format(b64)}
         else:
             raise ValueError('Either password or token must be provided')

--- a/nuxeo/operation.py
+++ b/nuxeo/operation.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from .blob import BlobInfo
+from .compat import text
 
 try:
     from typing import Any, Dict, List, Optional, Text, Union
@@ -36,7 +37,7 @@ class Operation(object):
                    + 'upload/'
                    + input_.service.batchid
                    + '/'
-                   + str(input_.fileIdx)
+                   + text(input_.fileIdx)
                    + '/execute/'
                    + self._type)
             input_ = None

--- a/nuxeo/repository.py
+++ b/nuxeo/repository.py
@@ -1,10 +1,9 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from urllib import urlencode
-
 from requests import HTTPError
 
+from .compat import urlencode
 from .document import Document
 from .exceptions import UnavailableConvertor
 from .workflow import Workflow
@@ -127,7 +126,7 @@ class Repository(object):
 
     def fetch_audit(self, path):
         # type: (Text) -> Dict[Text, Any]
-        return self.service.request(self._get_path(path) + '/@audit')
+        return self.service.request(self._get_path(path), adapter='audit')
 
     def fetch_blob(self, path, xpath='blobholder:0'):
         # type: (Text, Text) -> Union[Text, Dict[Text, Any], bytes]
@@ -161,7 +160,7 @@ class Repository(object):
 
     def fetch_workflows(self, path):
         # type: (Text) -> List[Workflow]
-        req = self.service.request(self._get_path(path) + '/@workflow')
+        req = self.service.request(self._get_path(path), adapter='workflow')
         return self.service.workflows().map(req, Workflow)
 
     def follow_transition(self, uid, name):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 # coding: utf-8
-from __future__ import print_function
 from __future__ import unicode_literals
 
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,7 @@ def georges(server):
         'lastName': 'Abitbol',
         'firstName': 'Georges',
         'username': 'georges',
+        'email': 'georges@example.com',
         'company': 'Pom Pom Gali resort',
         'password': 'Test'}
     return server.users().create(opts)

--- a/tests/test_batchupload.py
+++ b/tests/test_batchupload.py
@@ -101,16 +101,13 @@ def test_iter_content(server, batch):
         os.remove(file_out)
 
 
-def test_mimetype(monkeypatch):
+def test_mimetype():
     test = 'test.bmp'
     with open(test, 'wb') as f:
         f.write(b'\x00' + os.urandom(1024*1024) + b'\x00')
     try:
         blob = FileBlob(test)
-        assert blob.get_mimetype() == 'image/bmp'
-        monkeypatch.setattr(sys, 'platform', 'win32')
-        blob = FileBlob(test)
-        assert blob.get_mimetype() == 'image/x-ms-bmp'
+        assert blob.get_mimetype() in ['image/bmp', 'image/x-ms-bmp']
     finally:
         os.remove(test)
 

--- a/tests/test_batchupload.py
+++ b/tests/test_batchupload.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import hashlib
 import os
+import sys
 
 import pytest
 import sys
@@ -67,7 +68,9 @@ def test_operation(server, batch):
         doc = server.repository(schemas=['dublincore', 'file']).fetch(
             pytest.ws_root_path + '/Document')
         assert doc.properties['file:content'] is not None
-        assert doc.fetch_blob() == 'data'
+        blob = doc.fetch_blob()
+        assert isinstance(blob, bytes)
+        assert blob == b'data'
     finally:
         doc.delete()
 
@@ -97,6 +100,20 @@ def test_iter_content(server, batch):
         doc.delete()
         os.remove(file_in)
         os.remove(file_out)
+
+
+def test_mimetype(monkeypatch):
+    test = 'test.bmp'
+    with open(test, 'wb') as f:
+        f.write(b'\x00' + os.urandom(1024*1024) + b'\x00')
+    try:
+        blob = FileBlob(test)
+        assert blob.get_mimetype() == 'image/bmp'
+        monkeypatch.setattr(sys, 'platform', 'win32')
+        blob = FileBlob(test)
+        assert blob.get_mimetype() == 'image/x-ms-bmp'
+    finally:
+        os.remove(test)
 
 
 def test_wrong_batch_id(server):

--- a/tests/test_batchupload.py
+++ b/tests/test_batchupload.py
@@ -6,7 +6,6 @@ import os
 import sys
 
 import pytest
-import sys
 from requests import HTTPError
 
 from nuxeo.batchupload import BatchUpload

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,8 +1,11 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-import pytest
 import time
+
+import pytest
+
+from nuxeo.compat import text
 
 
 @pytest.fixture(scope='function')
@@ -37,7 +40,7 @@ def test_fetch_unknown_group(server):
 
 
 def test_update_group(server, group):
-    grouplabel = str(int(round(time.time() * 1000)))
+    grouplabel = text(int(round(time.time() * 1000)))
     group.grouplabel = grouplabel
     group.save()
     group = server.groups().fetch('plops')

--- a/tests/test_nuxeo.py
+++ b/tests/test_nuxeo.py
@@ -5,14 +5,13 @@ import json
 import os
 import re
 import sys
-import uuid
 
 import pkg_resources
 import pytest
 import requests
 from requests import HTTPError
 
-from nuxeo.__init__ import _extract_version
+from nuxeo import _extract_version
 from nuxeo.blob import Blob
 from nuxeo.exceptions import Unauthorized
 from nuxeo.nuxeo import Nuxeo

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,9 +1,8 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from requests import HTTPError
-
 import pytest
+from requests import HTTPError
 
 
 def test_document_fetch_by_property(server):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -6,6 +6,7 @@ import operator
 import pytest
 from requests import HTTPError
 
+from nuxeo.compat import get_bytes, get_error_message
 from nuxeo.document import Document
 from nuxeo.exceptions import UnavailableConvertor
 
@@ -25,7 +26,8 @@ def test_add_remove_permission(doc):
 def test_bogus_converter(doc):
     with pytest.raises(ValueError) as e:
         doc.convert({'converter': 'converterthatdoesntexist'})
-    assert e.value.message == 'Converter converterthatdoesntexist is not registered'
+    msg = get_error_message(e.value)
+    assert msg == 'Converter converterthatdoesntexist is not registered'
 
 
 def test_convert(doc):
@@ -105,7 +107,7 @@ def test_fetch_acls(doc):
 
 
 def test_fetch_blob(doc):
-    assert doc.fetch_blob() == 'foo'
+    assert doc.fetch_blob() == b'foo'
 
 
 def test_fetch_non_existing(repository):
@@ -114,9 +116,9 @@ def test_fetch_non_existing(repository):
 
 def test_fetch_rendition(doc):
     res = doc.fetch_rendition('xmlExport')
-    assert '<?xml version="1.0" encoding="UTF-8"?>' in res
+    assert b'<?xml version="1.0" encoding="UTF-8"?>' in res
     path = '<path>' + pytest.ws_python_tests_path[1:] + '</path>'
-    assert path in res
+    assert get_bytes(path) in res
 
 
 def test_fetch_renditions(doc):

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -5,6 +5,7 @@ import time
 
 import pytest
 
+from nuxeo.compat import text
 from nuxeo.nuxeo import Nuxeo
 from nuxeo.users import User
 
@@ -46,7 +47,7 @@ def test_lazy_loading(server, georges):
 
 
 def test_update_user(server, georges):
-    company = str(int(round(time.time() * 1000)))
+    company = text(int(round(time.time() * 1000)))
     georges.properties['company'] = company
     georges.save()
     user = server.users().fetch('georges')

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -33,13 +33,15 @@ def test_basic_workflow(workflows, doc, georges):
             'participants': ['user:Administrator'],
             'assignees': ['user:Administrator'],
             'end_date': '2011-10-23T12:00:00.00Z'}
-        task.delegate(georges.id, comment='a comment')
+        task.delegate(['user:{}'.format(georges.id)], comment='a comment')
         task.complete('start_review', infos, comment='a comment')
         assert len(doc.fetch_workflows()) == 1
         assert task.state == 'ended'
         tasks = workflow.fetch_tasks()
         assert len(tasks) == 1
         task = tasks[0]
+        # NXPY-12: Reassign task give _read() error
+        task.reassign(['user:{}'.format(georges.id)], comment='a comment')
         task.complete('validate', {'comment': 'a comment'})
         assert task.state == 'ended'
         assert not doc.fetch_workflows()


### PR DESCRIPTION
Add nuxeo/compat.py to manage imports that depends on the python version, and helpers (get_bytes(), get_text(), get_error_message()).
- Add test_batchupload.py::test_mimetype()
- Add test_nuxeo.py::test_request_token()