### PR TITLE
NXPY-59: Ensure the retreived data length respects the Content-Length HTTP header

### DIFF
--- a/ftest/itests.xml
+++ b/ftest/itests.xml
@@ -27,7 +27,6 @@
         <arg value="--showlocals" />
         <arg value="--exitfirst" />
         <arg value="--no-print-logs" />
-        <arg value="--log-level=CRITICAL" />
         <arg value="../tests" />
       </exec>
       <echo level="info">################### Ended Nuxeo Python Client functional tests ###################</echo>

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -128,13 +128,12 @@ class NuxeoClient(object):
         :param headers: the headers for the HTTP request
         :param data: data to put in the body
         :param raw: if True, don't parse the data to JSON
-        :param kwargs: other parameters accepted by
-               :func:`requests.request`
+        :param kwargs: other parameters accepted by :func:`requests.request`
         :return: the HTTP response
         """
-        if method not in ('GET', 'HEAD', 'POST', 'PUT',
-                          'DELETE', 'CONNECT', 'OPTIONS', 'TRACE'):
-            raise ValueError('method parameter is not a valid HTTP method.')
+
+        if method not in ('GET', 'POST', 'PUT', 'DELETE'):
+            raise ValueError('invalid {!r} HTTP method'.format(method))
 
         # Construct the full URL without double slashes
         url = self.host + path.lstrip('/')
@@ -272,7 +271,7 @@ class NuxeoClient(object):
                            else HTTPError)
 
             error = error_class.parse(error_data)
-            logger.exception('Remote exception: {}'.format(error))
+            logger.exception('Remote exception: %r', error)
         else:
             logger.exception(text(error))
         return error

--- a/nuxeo/exceptions.py
+++ b/nuxeo/exceptions.py
@@ -20,11 +20,15 @@ class CorruptedFile(ValueError):
         self.server_digest = server_digest
         self.local_digest = local_digest
 
-    def __str__(self):
+    def __repr__(self):
         # type: () -> Text
         err = ('Corrupted file {!r}: server digest '
                'is {!r}, local digest is {!r}')
         return err.format(self.filename, self.server_digest, self.local_digest)
+
+    def __str__(self):
+        # type: () -> Text
+        return repr(self)
 
 
 class EmptyFile(ValueError):
@@ -34,9 +38,13 @@ class EmptyFile(ValueError):
         # type: (Text) -> None
         self.name = name
 
-    def __str__(self):
+    def __repr__(self):
         # type: () -> Text
         return 'File {!r} is empty.'.format(self.name)
+
+    def __str__(self):
+        # type: () -> Text
+        return repr(self)
 
 
 class HTTPError(Exception):
@@ -52,9 +60,13 @@ class HTTPError(Exception):
         for key, default in HTTPError._valid_properties.items():
             setattr(self, key, kwargs.get(key, default))
 
-    def __str__(self):
+    def __repr__(self):
         # type: () -> Text
         return '{} error: {}'.format(self.status, get_text(self.message))
+
+    def __str__(self):
+        # type: () -> Text
+        return repr(self)
 
     @classmethod
     def parse(cls, json):
@@ -112,10 +124,14 @@ class UnavailableConvertor(Exception):
         self.options = options
         self.message = text(self)
 
-    def __str__(self):
+    def __repr__(self):
         # type: () -> Text
         err = 'Conversion with options {!r} is not available'
         return err.format(self.options)
+
+    def __str__(self):
+        # type: () -> Text
+        return repr(self)
 
 
 class UploadError(OSError):
@@ -127,9 +143,13 @@ class UploadError(OSError):
         self.name = name
         self.chunk = chunk
 
-    def __str__(self):
+    def __repr__(self):
         # type: () -> Text
         err = 'Unable to upload file {!r}'.format(self.name)
         if self.chunk:
             err = '{} (failed at chunk {})'.format(err, self.chunk)
         return err
+
+    def __str__(self):
+        # type: () -> Text
+        return repr(self)

--- a/nuxeo/exceptions.py
+++ b/nuxeo/exceptions.py
@@ -68,6 +68,24 @@ class HTTPError(Exception):
         return model
 
 
+class IncompleteRead(IOError):
+    """ Response length doesn't match expected Content-Length. """
+
+    def __init__(self, actual_length, expected_length):
+        # type: (int, int) -> None
+        self.actual = actual_length
+        self.expected = expected_length
+
+    def __repr__(self):
+        # type: () -> Text
+        return 'IncompleteRead({} bytes read, {} expected)'.format(
+            self.actual, self.expected)
+
+    def __str__(self):
+        # type: () -> Text
+        return repr(self)
+
+
 class InvalidBatch(ValueError):
     """
     Exception thrown when accessing inexistant or deleted batches.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,12 +43,15 @@ def cleanup(request, server):
 
 @pytest.fixture(scope='module')
 def directory(server):
-    directory = server.directories.get('nature')
+    directory_ = server.directories.get('nature')
+
+    # Ensure the old test child is removed
     try:
-        directory.delete('foo')
+        directory_.delete('foo')
     except HTTPError:
         pass
-    return directory
+
+    return directory_
 
 
 @pytest.fixture(scope='module')
@@ -58,8 +61,8 @@ def repository(server):
 
 @pytest.fixture(scope='module')
 def server():
-    server = Nuxeo(host=os.environ.get('NXDRIVE_TEST_NUXEO_URL',
+    remote = Nuxeo(host=os.environ.get('NXDRIVE_TEST_NUXEO_URL',
                                        'http://localhost:8080/nuxeo'),
                    auth=('Administrator', 'Administrator'))
-    server.client.set(schemas=['dublincore'])
-    return server
+    remote.client.set(schemas=['dublincore'])
+    return remote


### PR DESCRIPTION
We now log everything whatever the content size (priceless when debugging, espacially now that it will be used in Drive).

Also:
* Allow only internally used HTTP methods
* Add `__repr__()` to custom exceptions
* Little improvements in the test Server class
* Fix 2 flake8 warnings in tests
* Re-enable tests logging