### PR TITLE
NXPY-58: Fix operations caching

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ dev
 
 Release date: ``2018-05-xx``
 
--`NXPY-58 <https://jira.nuxeo.com/browse/NXPY-58>`__: Handle operation's parameter of type 'long'
+- `NXPY-58 <https://jira.nuxeo.com/browse/NXPY-58>`__: Modify the client to fit in Nuxeo Drive
 
 
 2.0.0

--- a/nuxeo/operations.py
+++ b/nuxeo/operations.py
@@ -45,9 +45,12 @@ PARAM_TYPES = {
 
 class API(APIEndpoint):
     """ Endpoint for operations. """
+
+    # Operations cache
+    ops = {}  # type: Dict[Text, Any]
+
     def __init__(self, client, endpoint='site/automation', headers=None):
         # type: (NuxeoClient, Text, Optional[Dict[Text, Text]]) -> None
-        self.ops = {}  # type: Dict[Text, Any]
         headers = headers or {}
         headers.update({
             'Content-Type': 'application/json+nxrequest',

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -22,7 +22,6 @@ def test_document_fetch_by_property_params_validation(server):
     operation = server.operations.new('Document.FetchByProperty')
     operation.params = {'property': 'dc:title'}
 
-    assert not server.operations.ops
     with pytest.raises(BadQuery):
         operation.execute(check_params=True)
     assert server.operations.ops


### PR DESCRIPTION
To be able to use a custom cache on the Drive side, I needed to move the `ops` attribute outside `__init__()`.