### PR TITLE
NXPY-58: Do not log the exception in Client._handle_error()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,10 @@
 Changelog
 =========
 
-dev
----
+2.0.1
+-----
 
-Release date: ``2018-05-xx``
+Release date: ``2018-05-31``
 
 - `NXPY-58 <https://jira.nuxeo.com/browse/NXPY-58>`__: Modify the client to fit in Nuxeo Drive
 

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -292,7 +292,7 @@ class NuxeoClient(object):
                            else HTTPError)
 
             error = error_class.parse(error_data)
-        logger.exception(error)
+        logger.error(error)
         return error
 
 

--- a/nuxeo/exceptions.py
+++ b/nuxeo/exceptions.py
@@ -61,7 +61,7 @@ class HTTPError(NuxeoError):
 
     def __repr__(self):
         # type: () -> Text
-        return '%s(%s), error: %s, server trace: %r' % (
+        return '%s(%r), error: %s, server trace: %r' % (
             type(self).__name__, self.status, self.message, self.stacktrace)
 
     def __str__(self):


### PR DESCRIPTION
If there is another exception in between the current exception in process and the exception logging, the logged exception will not be the good one. It just adds noise, because `logging.exception()` logs the latest exception .