### PR TITLE
NXPY-67: Fix Python 3.7 DeprecationWarning with ABCs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ dev
 Release date: ``2018-06-xx``
 
 - `NXPY-65 <https://jira.nuxeo.com/browse/NXPY-65>`__: Fix bytes <> str warnings
+- `NXPY-67 <https://jira.nuxeo.com/browse/NXPY-67>`__: Fix Python 3.7 DeprecationWarning with ABCs
 
 Technical changes
 -----------------

--- a/nuxeo/operations.py
+++ b/nuxeo/operations.py
@@ -1,7 +1,10 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from . import constants
 from .compat import get_text, long, text

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Topic :: Software Development :: Libraries
 
 [options]


### PR DESCRIPTION
```python
operations.py:4: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working.
```