### PR TITLE
NXPY-72: rely only on 'application/json' content type

### DIFF
--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -59,7 +59,7 @@ class NuxeoClient(object):
             'X-Application-Name': app_name,
             'X-Client-Version': version,
             'User-Agent': app_name + '/' + version,
-            'Accept': 'application/json+nxentity, */*'
+            'Accept': 'application/json, */*'
         }
         self.schemas = kwargs.get('schemas', '*')
         self.repository = kwargs.pop('repository', 'default')

--- a/nuxeo/operations.py
+++ b/nuxeo/operations.py
@@ -56,7 +56,7 @@ class API(APIEndpoint):
         # type: (NuxeoClient, Text, Optional[Dict[Text, Text]]) -> None
         headers = headers or {}
         headers.update({
-            'Content-Type': 'application/json+nxrequest',
+            'Content-Type': 'application/json',
             'X-NXproperties': '*'
         })
         super(API, self).__init__(


### PR DESCRIPTION
This change should work on any Nuxeo version (it did on the JS client), but I did not find any jobs running tests on any LTS version, did I miss something?