### PR TITLE
NXPY-74: Support Operation context

### DIFF
--- a/nuxeo/models.py
+++ b/nuxeo/models.py
@@ -641,6 +641,7 @@ class Operation(Model):
         'command': None,
         'input_obj': None,
         'params': {},
+        'context': None,
         'progress': 0,
     }
     service = None  # type: OperationsAPI

--- a/nuxeo/operations.py
+++ b/nuxeo/operations.py
@@ -231,6 +231,8 @@ class API(APIEndpoint):
         return command, input_obj, params, context
 
     def build_payload(self, params, context):
+        # type: (Dict[Text, Any], Dict[Text, Any]) -> Dict[Text, Any]
+        """ Create sanitized operation payload. """
         data = {'params': self.sanitize(params)}  # type: Dict[Text, Any]
         clean_context = self.sanitize(context)  # type: Dict[Text, Any]
         if clean_context:

--- a/nuxeo/operations.py
+++ b/nuxeo/operations.py
@@ -170,7 +170,7 @@ class API(APIEndpoint):
         check_suspended = kwargs.pop('check_suspended', None)
         enrichers = kwargs.pop('enrichers', None)
 
-        command, input_obj, params = self.get_attributes(operation, **kwargs)
+        command, input_obj, params, context = self.get_attributes(operation, **kwargs)
 
         if kwargs.pop('check_params', constants.CHECK_PARAMS):
             self.check_params(command, params)
@@ -187,7 +187,7 @@ class API(APIEndpoint):
         if void_op:
             headers['X-NXVoidOperation'] = 'true'
 
-        data = self.get_params(params)
+        data = self.build_payload(params, context)
 
         if input_obj:
             if isinstance(input_obj, list):
@@ -221,37 +221,46 @@ class API(APIEndpoint):
         if operation:
             command = operation.command
             input_obj = operation.input_obj
+            context = operation.context
             params = operation.params
         else:
             command = kwargs.pop('command', None)
             input_obj = kwargs.pop('input_obj', None)
+            context = kwargs.pop('context', None)
             params = kwargs.pop('params', kwargs)
-        return command, input_obj, params
+        return command, input_obj, params, context
+
+    def build_payload(self, params, context):
+        data = {'params': self.sanitize(params)}  # type: Dict[Text, Any]
+        clean_context = self.sanitize(context)  # type: Dict[Text, Any]
+        if clean_context:
+            data['context'] = clean_context
+
+        return data
 
     @staticmethod
-    def get_params(params):
+    def sanitize(obj):
         # type: (Dict[Text, Any]) -> Dict[Text, Any]
-        """ Get the operation parameters. """
-        data = {'params': {}}  # type: Dict[Text, Any]
+        """ Sanitize the operation parameters. """
+        if not obj:
+            return {}
 
-        for k, v in params.items():
+        clean_obj = {}  # type: Dict[Text, Any]
+
+        for k, v in obj.items():
             if v is None:
                 continue
 
-            if k == 'context' and v is not None:
-                data['context'] = v
-                continue
-
             if k != 'properties':
-                data['params'][k] = v
+                clean_obj[k] = v
                 continue
 
             # v can only be a dict
             contents = ['{}={}'.format(name, get_text(value))
                         for name, value in v.items()]
-            data['params'][k] = '\n'.join(contents)
+            clean_obj[k] = '\n'.join(contents)
 
-        return data
+        return clean_obj
 
     def new(self, command, **kwargs):
         # type: (Text, Any) -> Operation

--- a/nuxeo/operations.py
+++ b/nuxeo/operations.py
@@ -238,6 +238,10 @@ class API(APIEndpoint):
             if v is None:
                 continue
 
+            if k == 'context' and v is not None:
+                data['context'] = v
+                continue
+
             if k != 'properties':
                 data['params'][k] = v
                 continue

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -58,3 +58,10 @@ def test_params_setter(server):
     assert params['param1'] == 'bar'
     assert params['param2'] == 'bar'
     assert params['param3'] == 'plop'
+
+
+def test_context_setter(server):
+    operation = server.operations.new('Noop')
+    operation.context = {'currentDocument': 'foo'}
+    context = operation.context
+    assert context['currentDocument'] == 'foo'

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -63,5 +63,6 @@ def test_params_setter(server):
 def test_context_setter(server):
     operation = server.operations.new('Noop')
     operation.context = {'currentDocument': 'foo'}
-    context = operation.context
-    assert context['currentDocument'] == 'foo'
+    with pytest.raises(HTTPError):
+        operation.execute()
+    assert operation.context['currentDocument'] == 'foo'


### PR DESCRIPTION
I have created this simple fix to support `context` in an Operation payload (as required by e.g. `FileManager.Import`). Following sample code works now as expected:

```
    nx = get_nuxeo_client()
    operation = nx.operations.new('FileManager.Import')
    operation.params = {
        'context': {
            'currentDocument': "/default-domain/UserWorkspaces/Administrator"
        }
    }
    operation.input_obj = blob
    operation.execute()
```