### PR TITLE
NXPY-80: Stick with pytest < 4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.0.5
+-----
+
+Release date: ``2019-xx-xx``
+
+- `NXPY-80 <https://jira.nuxeo.com/browse/NXPY-80>`__: Stick with pytest < 4 to prevent internal error due to the use of deprecated ``pytest_namespace``
+
 2.0.4
 -----
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Release date: ``2019-xx-xx``
 - `NXPY-80 <https://jira.nuxeo.com/browse/NXPY-80>`__: Stick with pytest < 4 to prevent internal error due to the use of deprecated ``pytest_namespace``
 - `NXPY-81 <https://jira.nuxeo.com/browse/NXPY-81>`__: Fix flake8 errors and add flake8 to the CI
 - `NXPY-82 <https://jira.nuxeo.com/browse/NXPY-82>`__: Fix ``test_convert_xpath()``
+- `NXPY-83 <https://jira.nuxeo.com/browse/NXPY-83>`__: Fix ``test_convert()`` and ``test_convert_given_converter()``
 
 2.0.4
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 Release date: ``2019-xx-xx``
 
 - `NXPY-80 <https://jira.nuxeo.com/browse/NXPY-80>`__: Stick with pytest < 4 to prevent internal error due to the use of deprecated ``pytest_namespace``
+- `NXPY-81 <https://jira.nuxeo.com/browse/NXPY-81>`__: Fix flake8 errors and add flake8 to the CI
 
 2.0.4
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Release date: ``2019-xx-xx``
 
 - `NXPY-80 <https://jira.nuxeo.com/browse/NXPY-80>`__: Stick with pytest < 4 to prevent internal error due to the use of deprecated ``pytest_namespace``
 - `NXPY-81 <https://jira.nuxeo.com/browse/NXPY-81>`__: Fix flake8 errors and add flake8 to the CI
+- `NXPY-82 <https://jira.nuxeo.com/browse/NXPY-82>`__: Fix ``test_convert_xpath()``
 
 2.0.4
 -----

--- a/examples/find_duplicates.py
+++ b/examples/find_duplicates.py
@@ -89,7 +89,7 @@ def find_duplicates_in_folder(folder):
 
 
 def find_duplicates_of_uid(uid):
-    if not re.match('^[a-fA-F\d]{8}-[a-fA-F\d]{4}-[a-fA-F\d]{4}-[a-fA-F\d]{4}-[a-fA-F\d]{12}$', uid):
+    if not re.match(r'^[a-fA-F\d]{8}-[a-fA-F\d]{4}-[a-fA-F\d]{4}-[a-fA-F\d]{4}-[a-fA-F\d]{12}$', uid):
         color_print('Not a valid uid.', BColors.FAIL)
     else:
         try:

--- a/nuxeo/__init__.py
+++ b/nuxeo/__init__.py
@@ -18,7 +18,7 @@ from __future__ import unicode_literals
 
 
 __author__ = 'Nuxeo'
-__version__ = '2.0.4'
+__version__ = '2.0.5'
 __copyright__ = """
     Copyright Nuxeo (https://www.nuxeo.com) and others.
 

--- a/nuxeo/auth.py
+++ b/nuxeo/auth.py
@@ -8,8 +8,8 @@ from .compat import get_bytes
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Text
-        from requests import Request
+        from typing import Text  # noqa
+        from requests import Request  # noqa
 except ImportError:
     pass
 

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -19,8 +19,8 @@ from .utils import json_helper
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Any, Dict, Optional, Text, Tuple, Type, Union
-        from requests.auth import AuthBase
+        from typing import Any, Dict, Optional, Text, Tuple, Type, Union  # noqa
+        from requests.auth import AuthBase  # noqa
         AuthType = Optional[Union[Tuple[Text, Text], AuthBase]]
 except ImportError:
     pass

--- a/nuxeo/compat.py
+++ b/nuxeo/compat.py
@@ -4,16 +4,16 @@ from __future__ import unicode_literals
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Text, Type, Union
-        from requests import HTTPError
+        from typing import Text, Type, Union  # noqa
+        from requests import HTTPError  # noqa
 except ImportError:
     pass
 
 try:
     from urllib.parse import quote, urlencode
 except ImportError:
-    from urllib2 import quote
-    from urllib import urlencode
+    from urllib2 import quote  # noqa
+    from urllib import urlencode  # noqa
 
 try:
     long = long

--- a/nuxeo/directories.py
+++ b/nuxeo/directories.py
@@ -8,8 +8,8 @@ from .models import Directory, DirectoryEntry
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Any, Dict, Text, Optional, Union
-        from .client import NuxeoClient
+        from typing import Any, Dict, Text, Optional, Union  # noqa
+        from .client import NuxeoClient  # noqa
 except ImportError:
     pass
 

--- a/nuxeo/documents.py
+++ b/nuxeo/documents.py
@@ -10,10 +10,10 @@ from .workflows import API as WorkflowsAPI
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Any, Dict, List, Optional, Text, Union
-        from .client import NuxeoClient
-        from .models import Blob, Workflow
-        from .operations import API as OperationsAPI
+        from typing import Any, Dict, List, Optional, Text, Union  # noqa
+        from .client import NuxeoClient  # noqa
+        from .models import Blob, Workflow  # noqa
+        from .operations import API as OperationsAPI  # noqa
 except ImportError:
     pass
 

--- a/nuxeo/endpoint.py
+++ b/nuxeo/endpoint.py
@@ -8,9 +8,9 @@ from .exceptions import BadQuery, HTTPError
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Any, Dict, Optional, Text, Type, Union
-        from .client import NuxeoClient
-        from .models import Model
+        from typing import Any, Dict, Optional, Text, Type, Union  # noqa
+        from .client import NuxeoClient  # noqa
+        from .models import Model  # noqa
 except ImportError:
     pass
 

--- a/nuxeo/exceptions.py
+++ b/nuxeo/exceptions.py
@@ -6,7 +6,7 @@ from .compat import text
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Any, Dict, Optional, Text
+        from typing import Any, Dict, Optional, Text  # noqa
 except ImportError:
     pass
 

--- a/nuxeo/groups.py
+++ b/nuxeo/groups.py
@@ -7,8 +7,8 @@ from .models import Group
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Dict, Optional, Text
-        from .client import NuxeoClient
+        from typing import Dict, Optional, Text  # noqa
+        from .client import NuxeoClient  # noqa
 except ImportError:
     pass
 

--- a/nuxeo/models.py
+++ b/nuxeo/models.py
@@ -11,17 +11,17 @@ from .utils import guess_mimetype
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Any, BinaryIO, Dict, List, Optional, Text, Union
-        from io import FileIO
-        from .directories import API as DirectoriesAPI
-        from .documents import API as DocumentsAPI
-        from .endpoint import APIEndpoint
-        from .groups import API as GroupsAPI
-        from .operations import API as OperationsAPI
-        from .tasks import API as TasksAPI
-        from .uploads import API as UploadsAPI
-        from .users import API as UsersAPI
-        from .workflows import API as WorkflowsAPI
+        from typing import Any, BinaryIO, Dict, List, Optional, Text, Union  # noqa
+        from io import FileIO  # noqa
+        from .directories import API as DirectoriesAPI  # noqa
+        from .documents import API as DocumentsAPI  # noqa
+        from .endpoint import APIEndpoint  # noqa
+        from .groups import API as GroupsAPI  # noqa
+        from .operations import API as OperationsAPI  # noqa
+        from .tasks import API as TasksAPI  # noqa
+        from .uploads import API as UploadsAPI  # noqa
+        from .users import API as UsersAPI  # noqa
+        from .workflows import API as WorkflowsAPI  # noqa
 except ImportError:
     pass
 
@@ -320,8 +320,8 @@ class FileBlob(Blob):
         self.path = path
         self.name = os.path.basename(self.path)
         self.size = os.path.getsize(self.path)
-        self.mimetype = (self.mimetype or
-                         guess_mimetype(self.path))  # type: Text
+        self.mimetype = (self.mimetype
+                         or guess_mimetype(self.path))  # type: Text
 
     @property
     def data(self):

--- a/nuxeo/operations.py
+++ b/nuxeo/operations.py
@@ -16,9 +16,9 @@ from .utils import get_digester
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from requests import Response
-        from typing import Any, Dict, Optional, Text, Tuple, Type
-        from .client import NuxeoClient
+        from requests import Response  # noqa
+        from typing import Any, Dict, Optional, Text, Tuple, Type  # noqa
+        from .client import NuxeoClient  # noqa
 except ImportError:
     pass
 

--- a/nuxeo/tasks.py
+++ b/nuxeo/tasks.py
@@ -9,9 +9,9 @@ from .models import Task
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Any, Dict, List, Optional, Text, Union
-        from .client import NuxeoClient
-        from .models import Workflow
+        from typing import Any, Dict, List, Optional, Text, Union  # noqa
+        from .client import NuxeoClient  # noqa
+        from .models import Workflow  # noqa
 except ImportError:
     pass
 

--- a/nuxeo/uploads.py
+++ b/nuxeo/uploads.py
@@ -11,9 +11,9 @@ from .utils import SwapAttr
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Any, Dict, List, Optional, Text, Tuple, Union
-        from .client import NuxeoClient
-        OptInt = Optional[int]
+        from typing import Any, Dict, List, Optional, Text, Tuple, Union  # noqa
+        from .client import NuxeoClient  # noqa
+        OptInt = Optional[int]  # noqa
 except ImportError:
     pass
 
@@ -152,8 +152,8 @@ class API(APIEndpoint):
             index = int(info.uploadedChunkIds[-1]) + 1
         else:  # It's a new upload
             chunk_size = UPLOAD_CHUNK_SIZE
-            chunk_count = (blob.size // chunk_size +
-                           (blob.size % chunk_size > 0))
+            chunk_count = (blob.size // chunk_size
+                           + (blob.size % chunk_size > 0))
             index = 0
 
         return chunk_size, chunk_count, index, info

--- a/nuxeo/users.py
+++ b/nuxeo/users.py
@@ -7,8 +7,8 @@ from .models import User
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Dict, Optional, Text
-        from .client import NuxeoClient
+        from typing import Dict, Optional, Text  # noqa
+        from .client import NuxeoClient  # noqa
 except ImportError:
     pass
 

--- a/nuxeo/utils.py
+++ b/nuxeo/utils.py
@@ -10,8 +10,8 @@ import hashlib
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from _hashlib import HASH
-        from typing import Any, Dict, Optional, Text, Type, Union
+        from _hashlib import HASH  # noqa
+        from typing import Any, Dict, Optional, Text, Type, Union  # noqa
 except ImportError:
     pass
 

--- a/nuxeo/workflows.py
+++ b/nuxeo/workflows.py
@@ -8,10 +8,10 @@ from .utils import SwapAttr
 try:
     from typing import TYPE_CHECKING
     if TYPE_CHECKING:
-        from typing import Any, Dict, List, Optional, Text, Union
-        from .client import NuxeoClient
-        from .models import Document
-        from .tasks import API as TasksAPI
+        from typing import Any, Dict, List, Optional, Text, Union  # noqa
+        from .client import NuxeoClient  # noqa
+        from .models import Document  # noqa
+        from .tasks import API as TasksAPI  # noqa
 except ImportError:
     pass
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,19 +30,12 @@ zip-safe = False
 include_package_data = True
 packages = nuxeo
 install_requires = requests >= 2.12.2
-setup_requires = pytest-runner
-tests_require =
-    pytest < 4
-    pytest-cov
 
 [options.package_data]
 * = *.cfg, *.rst, *.txt
 
 [bdist_wheel]
 universal = 1
-
-[aliases]
-test = pytest
 
 [tool:pytest]
 addopts =
@@ -56,3 +49,16 @@ addopts =
     --log-level=CRITICAL
     -W error
     -v
+
+[flake8]
+ignore =
+    # E203 whitespace before ':', but E203 is not PEP 8 compliant
+    E203
+    # W503 line break before binary operator, but W503 is not PEP 8 compliant
+    W503
+max-line-length = 120
+exclude =
+    .eggs
+    .git
+    .tox
+    ftest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nuxeo
-version = 2.0.4
+version = 2.0.5
 author = Nuxeo
 author-email = maintainers-python@nuxeo.com
 description = Nuxeo REST API Python client
@@ -32,7 +32,7 @@ packages = nuxeo
 install_requires = requests >= 2.12.2
 setup_requires = pytest-runner
 tests_require =
-    pytest
+    pytest < 4
     pytest-cov
 
 [options.package_data]

--- a/tests/server.py
+++ b/tests/server.py
@@ -167,8 +167,7 @@ class Server(threading.Thread):
     @classmethod
     def basic_response_server(cls, **kwargs):
         return cls.text_response_server(
-            "HTTP/1.1 200 OK\r\n" +
-            "Content-Length: 0\r\n\r\n",
+            "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
             **kwargs
         )
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -33,8 +33,8 @@ class Doc(object):
                     name='foo-{}.txt'.format(idx))
                 batch.upload(blob)
 
-            batch.attach(pytest.ws_root_path + '/' +
-                         pytest.ws_python_test_name)
+            path = pytest.ws_root_path + '/' + pytest.ws_python_test_name
+            batch.attach(path)
         return self.doc
 
     def __exit__(self, *args):
@@ -65,7 +65,7 @@ def test_document_create_bytes_warning(server):
         BytesWarning: str() on a bytes instance
     """
     name = 'File.txt'
-    properties={'dc:title': name, 'note:note': b'some content'}
+    properties = {'dc:title': name, 'note:note': b'some content'}
     document = None
     try:
         document = server.operations.execute(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -109,7 +109,7 @@ def test_convert_xpath(server):
     with Doc(server, with_blob=True) as doc:
         try:
             res = doc.convert({'xpath': 'file:content', 'type': 'text/html'})
-            assert b'<html>' in res
+            assert b'<html' in res
             assert b'foo' in res
         except UnavailableConvertor:
             pass

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -69,7 +69,7 @@ def test_convert(server):
     with Doc(server, with_blob=True) as doc:
         try:
             res = doc.convert({'format': 'html'})
-            assert b'<html>' in res
+            assert b'<html' in res
             assert b'foo' in res
         except UnavailableConvertor:
             pass
@@ -79,7 +79,7 @@ def test_convert_given_converter(server):
     with Doc(server, with_blob=True) as doc:
         try:
             res = doc.convert({'converter': 'office2html'})
-            assert b'<html>' in res
+            assert b'<html' in res
             assert b'foo' in res
         except UnavailableConvertor:
             pass

--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,10 @@ envlist = py{27,34,35,36,37}
 skip_missing_interpreters = True
 
 [testenv]
-commands = python setup.py test
+deps =
+    flake8
+    pytest < 4
+    pytest-cov
+commands =
+    python -m flake8
+    python -m pytest


### PR DESCRIPTION
This is to prevent internal error due to the use of deprecated `pytest_namespace`.