### PR TITLE
NXDRIVE-1620: Do not open file descriptor on empty file

### DIFF
--- a/nuxeo/models.py
+++ b/nuxeo/models.py
@@ -290,6 +290,7 @@ class BufferBlob(Blob):
         """
         super(BufferBlob, self).__init__(**kwargs)
         self.buffer = data
+        self.size = len(self.buffer)
         self.mimetype = 'application/octet-stream'
 
     @property

--- a/nuxeo/uploads.py
+++ b/nuxeo/uploads.py
@@ -245,24 +245,38 @@ class API(APIEndpoint):
         :param callback: if not None, it is executed between each chunk
         :return: uploaded blob details
         """
-
-        return Uploader(self, batch, blob, chunked, chunk_size, callback)
+        chunked = chunked and self.blob.size > self.chunk_size
+        if chunked:
+            return ChunkUploader(self, batch, blob, chunk_size, callback)
+        return Uploader(self, batch, blob, chunk_size, callback)
 
 
 class Uploader:
     """ Helper for uploads """
-    def __init__(self, service, batch, blob, chunked, chunk_size, callback=None):
-        # type: (API, Batch, Blob, bool, int, Callable) -> None
+    chunked = False
+
+    def __init__(self, service, batch, blob, chunk_size, callback=None):
+        # type: (API, Batch, Blob, int, Callable) -> None
         self.service = service
         self.batch = batch
         self.blob = blob
-        self.chunked = chunked
         self.chunk_size = chunk_size
         self.callback = callback
         self.headers = service.headers.copy()
-        self.response = None
 
-        self.init()
+        self.response = None
+        self.chunk_size = self.blob.size or None
+        self.chunk_count = 1
+        self.index = 0
+        self.path = '{}/{}'.format(self.batch.batchId, self.batch._upload_idx)
+
+        self.headers.update({
+            'Cache-Control': 'no-cache',
+            'X-File-Name': quote(get_bytes(self.blob.name)),
+            'X-File-Size': text(self.blob.size),
+            'X-File-Type': self.blob.mimetype,
+            'Content-Length': text(self.blob.size),
+        })
 
     def __repr__(self):
         # type: () -> Text
@@ -277,42 +291,53 @@ class Uploader:
         # type: () -> Text
         return repr(self)
 
-    def init(self):
+    def is_complete(self):
+        return getattr(self, "_completed", default=False)
+
+    def upload(self):
         # type: () -> None
-        """ Compute the headers, the path, the chunking info, etc. """
-        self.chunked = self.chunked and self.blob.size > self.chunk_size
-
-        self.headers.update({
-            'Cache-Control': 'no-cache',
-            'X-File-Name': quote(get_bytes(self.blob.name)),
-            'X-File-Size': text(self.blob.size),
-            'X-File-Type': self.blob.mimetype,
-            'Content-Length': text(self.blob.size),
-        })
-
-        self.path = '{}/{}'.format(self.batch.batchId, self.batch._upload_idx)
-
-        if self.chunked:
-            chunk_size, chunk_count, index, info = self.service.state(
-                self.path, self.blob, self.chunk_size
+        """ Upload the file. """
+        with self.blob as src:
+            data = src if self.blob.size else None
+            self.response = self.service.send_data(
+                self.blob.name, data, self.path, self.chunked, self.index, self.headers
             )
+            if callable(self.callback):
+                self.callback(self)
+            setattr(self, "_completed", True)
+        self._update_batch()
 
-            self.headers.update({
-                'X-Upload-Type': 'chunked',
-                'X-Upload-Chunk-Count': text(chunk_count),
-                'Content-Length': text(chunk_size)
-            })
-        else:
-            chunk_size, chunk_count, index = self.blob.size or None, 1, 0
+    def _update_batch(self):
+        """ Add the uploaded blob info to the batch. """
+        if self.is_complete():
+            # All the parts have been uploaded, update the attributes
+            self.response.batch_id = self.batch.uid
+            self.batch.blobs[self.batch._upload_idx] = self.response
+            self.batch._upload_idx += 1
+
+
+class ChunkUploader(Uploader):
+    """ Helper for chunked uploads """
+    chunked = True
+
+    def __init__(self, service, batch, blob, chunk_size, callback=None):
+        # type: (API, Batch, Blob, int, Callable) -> None
+        super().__init__(service, batch, blob, chunk_size, callback=callback)
+        chunk_size, chunk_count, index, info = self.service.state(
+            self.path, self.blob, self.chunk_size
+        )
+        self.headers.update({
+            'X-Upload-Type': 'chunked',
+            'X-Upload-Chunk-Count': text(chunk_count),
+            'Content-Length': text(chunk_size)
+        })
 
         self.chunk_size = chunk_size
         self.chunk_count = chunk_count
         self.index = index
 
-    def upload(self):
-        # type: () -> None
-        """ Upload the file. """
-        list(self.iter_upload())
+    def is_complete(self):
+        return self.index == self.chunk_count
 
     def iter_upload(self):
         # type: () -> Generator
@@ -325,12 +350,11 @@ class Uploader:
         """
         with self.blob as src:
             # Seek to the right position if the upload is starting
-            if self.chunk_size:
-                src.seek(self.index * self.chunk_size)
+            src.seek(self.index * self.chunk_size)
 
             while self.index < self.chunk_count:
                 # Read a chunk of data, or use the file descriptor
-                data = src.read(self.chunk_size) if self.chunked else src
+                data = src.read(self.chunk_size)
                 # Upload it
                 self.response = self.service.send_data(
                     self.blob.name, data, self.path, self.chunked, self.index, self.headers
@@ -345,10 +369,6 @@ class Uploader:
 
         self._update_batch()
 
-    def _update_batch(self):
-        """ Add the uploaded blob info to the batch. """
-        if self.index == self.chunk_count:
-            # All the parts have been uploaded, update the attributes
-            self.response.batch_id = self.batch.uid
-            self.batch.blobs[self.batch._upload_idx] = self.response
-            self.batch._upload_idx += 1
+    def upload(self):
+        # type: () -> None
+        list(self.iter_upload())

--- a/nuxeo/uploads.py
+++ b/nuxeo/uploads.py
@@ -251,7 +251,7 @@ class API(APIEndpoint):
         return Uploader(self, batch, blob, chunk_size, callback)
 
 
-class Uploader:
+class Uploader(object):
     """ Helper for uploads """
     chunked = False
 

--- a/nuxeo/uploads.py
+++ b/nuxeo/uploads.py
@@ -245,7 +245,7 @@ class API(APIEndpoint):
         :param callback: if not None, it is executed between each chunk
         :return: uploaded blob details
         """
-        chunked = chunked and self.blob.size > self.chunk_size
+        chunked = chunked and blob.size > chunk_size
         if chunked:
             return ChunkUploader(self, batch, blob, chunk_size, callback)
         return Uploader(self, batch, blob, chunk_size, callback)
@@ -292,7 +292,7 @@ class Uploader:
         return repr(self)
 
     def is_complete(self):
-        return getattr(self, "_completed", default=False)
+        return getattr(self, "_completed", False)
 
     def upload(self):
         # type: () -> None
@@ -322,9 +322,9 @@ class ChunkUploader(Uploader):
 
     def __init__(self, service, batch, blob, chunk_size, callback=None):
         # type: (API, Batch, Blob, int, Callable) -> None
-        super().__init__(service, batch, blob, chunk_size, callback=callback)
+        super(ChunkUploader, self).__init__(service, batch, blob, chunk_size, callback=callback)
         chunk_size, chunk_count, index, info = self.service.state(
-            self.path, self.blob, self.chunk_size
+            self.path, self.blob, chunk_size
         )
         self.headers.update({
             'X-Upload-Type': 'chunked',

--- a/tests/test_batchupload.py
+++ b/tests/test_batchupload.py
@@ -165,6 +165,9 @@ def test_operation(server):
 
 @pytest.mark.parametrize('chunked', [False, True])
 def test_upload(chunked, server):
+    def callback(*args):
+        assert args
+
     batch = server.uploads.batch()
     file_in, file_out = 'test_in', 'test_out'
     with open(file_in, 'wb') as f:
@@ -174,7 +177,7 @@ def test_upload(chunked, server):
     try:
         blob = FileBlob(file_in, mimetype='application/octet-stream')
         assert repr(blob)
-        assert batch.upload(blob, chunked=chunked)
+        assert batch.upload(blob, chunked=chunked, callback=callback)
         operation = server.operations.new('Blob.AttachOnDocument')
         operation.params = {'document': pytest.ws_root_path + '/Document'}
         operation.input_obj = batch.get(0)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -140,6 +140,9 @@ def test_document_move(server):
     try:
         doc.move(pytest.ws_root_path + '/Test', 'new name')
         assert doc.path == pytest.ws_root_path + '/Test/new name'
+        children = server.documents.get_children(folder.uid)
+        assert len(children) == 1
+        assert children[0].uid == doc.uid
     finally:
         doc.delete()
         folder.delete()


### PR DESCRIPTION
Requests hangs indefinitely when the `data` of a `POST` request is a file descriptor to an empty file. This fix prevents this case from happening.