### PR TITLE
NXPY-105: Make a diffrence between HTTP 401 and 403 errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Release date: ``2019-xx-xx``
 - `NXPY-103 <https://jira.nuxeo.com/browse/NXPY-103>`__: Launch flake8 on actual client data
 - `NXPY-104 <https://jira.nuxeo.com/browse/NXPY-104>`__: Do not log server response based on content length but content type
 - `NXPY-105 <https://jira.nuxeo.com/browse/NXPY-105>`__: Make a diffrence between HTTP 401 and 403 errors
+- `NXPY-106 <https://jira.nuxeo.com/browse/NXPY-106>`__: Lower logging level in ``get_digester()``
 
 Technical changes
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,11 +9,14 @@ Release date: ``2019-xx-xx``
 - `NXPY-102 <https://jira.nuxeo.com/browse/NXPY-102>`__: Set Upload operations to void operations
 - `NXPY-103 <https://jira.nuxeo.com/browse/NXPY-103>`__: Launch flake8 on actual client data
 - `NXPY-104 <https://jira.nuxeo.com/browse/NXPY-104>`__: Do not log server response based on content length but content type
+- `NXPY-105 <https://jira.nuxeo.com/browse/NXPY-105>`__: Make a diffrence between HTTP 401 and 403 errors
 
 Technical changes
 -----------------
 
-- Added `void_op=True` keyword argument to nuxeo/uploads.py::\ ``API.execute()``
+- Added nuxeo/client.py::\ ``HTTP_ERROR``
+- Added nuxeo/exceptions.py::\ ``Forbidden``
+- Added ``void_op=True`` keyword argument to nuxeo/uploads.py::\ ``API.execute()``
 
 2.1.1
 -----

--- a/nuxeo/exceptions.py
+++ b/nuxeo/exceptions.py
@@ -80,12 +80,16 @@ class HTTPError(NuxeoError):
         return model
 
 
+class Forbidden(HTTPError):
+    """ Exception thrown when the HTTPError code is 403. """
+
+
 class InvalidBatch(NuxeoError):
     """ Exception thrown when accessing inexistant or deleted batches. """
 
 
 class Unauthorized(HTTPError):
-    """ Exception thrown when the HTTPError code is 401 or 403. """
+    """ Exception thrown when the HTTPError code is 401. """
 
 
 class UnavailableConvertor(NuxeoError):

--- a/nuxeo/utils.py
+++ b/nuxeo/utils.py
@@ -78,7 +78,7 @@ def get_digester(digest):
     func = get_digest_hash(algo) if algo else None
 
     if not func:
-        logger.error('No valid hash algorithm found for digest %r', digest)
+        logger.warning('No valid hash algorithm found for digest %r', digest)
 
     return func
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,4 @@ deps =
     sentry-sdk
 commands =
     python -m flake8 examples nuxeo tests
-    python -m pytest
+    python -m pytest {posargs}


### PR DESCRIPTION
* Added `Forbidden` exception;
* Introduced `HTTP_ERROR` in `nuxeo/client.py` to ease future addition and error handling;
* Let the possibility to pass arguments to `pytest` (eg `TOXENV=py37 tox -- -k test_upload_retry`);
* NXPY-106: Lower logging level in `get_digester()`.