### PR TITLE
NXPY-112: Update uploadedSize on each and every upload iteration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.2.2
+-----
+
+Release date: ``2019-xx-xx``
+
+- `NXPY-112 <https://jira.nuxeo.com/browse/NXPY-112>`__: Update uploadedSize on each and every upload iteration
+
 2.2.1
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -73,10 +73,10 @@ In the `nuxeo/constants.py <nuxeo/constants.py>`__ file, you have several consta
 used throughout the client that you can change to fit your needs. Some of them are:
 
 -  ``CHECK_PARAMS`` (False by default), to check operation's parameters for each and every HTTP calls.
--  ``CHUNK_LIMIT`` (10 Mio by default), the size above which the upload will automatically be chunked.
--  ``CHUNK_SIZE`` (8 Kio by default), the size of the chunks when downloading.
+-  ``CHUNK_LIMIT`` (10 MiB by default), the size above which the upload will automatically be chunked.
+-  ``CHUNK_SIZE`` (8 KiB by default), the size of the chunks when downloading.
 -  ``MAX_RETRY`` (3 by default), the number of retries for the upload of a given blob/chunk.
--  ``UPLOAD_CHUNK_SIZE`` (256 Kio by default), the size of the chunks when uploading.
+-  ``UPLOAD_CHUNK_SIZE`` (20 MiB by default), the size of the chunks when uploading.
 
 
 Run NXQL Queries

--- a/nuxeo/__init__.py
+++ b/nuxeo/__init__.py
@@ -8,17 +8,17 @@ You can always get the latest version of this module at:
 If that URL should fail, try contacting the author.
 
 Contributors:
-    Antoine Taillefer <ataillefer@nuxeo.com>
+    Antoine Taillefer
     Rémi Cattiau
     Mickaël Schoentgen <mschoentgen@nuxeo.com>
-    Léa Klein <lklein@nuxeo.com>
+    Léa Klein
     and https://github.com/nuxeo/nuxeo-python-client/graphs/contributors
 """
 from __future__ import unicode_literals
 
 
 __author__ = 'Nuxeo'
-__version__ = '2.2.1'
+__version__ = '2.2.2'
 __copyright__ = """
     Copyright Nuxeo (https://www.nuxeo.com) and others.
 

--- a/nuxeo/constants.py
+++ b/nuxeo/constants.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 CHECK_PARAMS = False
 
 # Chunk size to download files
-CHUNK_SIZE = 8192  # 8 Kio
+CHUNK_SIZE = 8192  # 8 KiB
 
 # API paths
 DEFAULT_API_PATH = 'api/v1'
@@ -22,4 +22,4 @@ DEFAULT_APP_NAME = 'Python client'
 MAX_RETRY = 3
 
 # Size of chunks for the upload
-UPLOAD_CHUNK_SIZE = 20 * 1024 * 1024  # 20 Mio
+UPLOAD_CHUNK_SIZE = 20 * 1024 * 1024  # 20 MiB

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nuxeo
-version = 2.2.1
+version = 2.2.2
 author = Nuxeo
 author-email = maintainers-python@nuxeo.com
 description = Nuxeo REST API Python client


### PR DESCRIPTION
Also:
- Use KiB and MiB rather than Kio and Mio.
- Fix `Blob.uploadType` never set.