### PR TITLE
NXPY-110: Max retries for all connections

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+fail_fast: true
+
+repos:
+-   repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black
+      language_version: python3.7
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: master
+    hooks:
+    - id: trailing-whitespace
+    - id: flake8
+    - id: end-of-file-fixer
+    - id: check-docstring-first
+    - id: requirements-txt-fixer
+    - id: check-ast
+    - id: no-commit-to-branch

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 Release date: ``2019-xx-xx``
 
 - `NXPY-112 <https://jira.nuxeo.com/browse/NXPY-112>`__: Update uploadedSize on each and every upload iteration
+- `NXPY-114 <https://jira.nuxeo.com/browse/NXPY-114>`__: Do not log the response of the CMIS endpoint
 
 2.2.1
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 Release date: ``2019-xx-xx``
 
 - `NXPY-112 <https://jira.nuxeo.com/browse/NXPY-112>`__: Update uploadedSize on each and every upload iteration
+- `NXPY-113 <https://jira.nuxeo.com/browse/NXPY-113>`__: Use ``requests.sessions.Session`` rather than the deprecated ``requests.session``
 - `NXPY-114 <https://jira.nuxeo.com/browse/NXPY-114>`__: Do not log the response of the CMIS endpoint
 
 2.2.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,21 @@ Changelog
 Release date: ``2019-xx-xx``
 
 - `NXPY-112 <https://jira.nuxeo.com/browse/NXPY-112>`__: Update uploadedSize on each and every upload iteration
+- `NXPY-110 <https://jira.nuxeo.com/browse/NXPY-110>`__: Max retries for all connections
 - `NXPY-113 <https://jira.nuxeo.com/browse/NXPY-113>`__: Use ``requests.sessions.Session`` rather than the deprecated ``requests.session``
 - `NXPY-114 <https://jira.nuxeo.com/browse/NXPY-114>`__: Do not log the response of the CMIS endpoint
+
+Technical changes
+-----------------
+
+- Added ``NuxeoClient.disable_retry()``
+- Added ``NuxeoClient.enable_retry()``
+- Added ``NuxeoClient.retries``
+- Added nuxeo/constants.py::\ ``MAX_RETRY``
+- Added nuxeo/constants.py::\ ``RETRY_BACKOFF_FACTOR``
+- Added nuxeo/constants.py::\ ``RETRY_METHODS``
+- Added nuxeo/constants.py::\ ``RETRY_STATUS_CODES``
+- Changed nuxeo/exceptions.py::\ ``HTTPError`` to inherits from ``requests.exceptions.RetryError`` and ``NuxeoError``
 
 2.2.1
 -----

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ used throughout the client that you can change to fit your needs. Some of them a
 -  ``CHECK_PARAMS`` (False by default), to check operation's parameters for each and every HTTP calls.
 -  ``CHUNK_LIMIT`` (10 MiB by default), the size above which the upload will automatically be chunked.
 -  ``CHUNK_SIZE`` (8 KiB by default), the size of the chunks when downloading.
--  ``MAX_RETRY`` (3 by default), the number of retries for the upload of a given blob/chunk.
+-  ``MAX_RETRY`` (5 by default), the number of retries for connection error on any HTTP call.
 -  ``UPLOAD_CHUNK_SIZE`` (20 MiB by default), the size of the chunks when uploading.
 
 

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -71,7 +71,7 @@ class NuxeoClient(object):
         }
         self.schemas = kwargs.get('schemas', '*')
         self.repository = kwargs.pop('repository', 'default')
-        self._session = requests.session()
+        self._session = requests.sessions.Session()
         cookies = kwargs.pop('cookies', None)
         if cookies:
             self._session.cookies = cookies

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -321,7 +321,11 @@ class NuxeoClient(object):
         content_type = headers.get('content-type', 'application/octet-stream')
         content = '<not yet handled, content-type={!r}>'.format(content_type)
 
-        if not response.content:
+        if response.url.endswith('json/cmis'):
+            # This endpoint returns too many information and pollute logs.
+            # Besides contents of this call are stored into the .server_info attr.
+            content = '<CMIS details saved into the *server_info* attr>'
+        elif not response.content:
             # response.content is empty when *void_op* is True,
             # meaning we do not want to get back what we sent
             # or the operation does not return anything by default

--- a/nuxeo/constants.py
+++ b/nuxeo/constants.py
@@ -18,8 +18,19 @@ Default value for the:
 """
 DEFAULT_APP_NAME = 'Python client'
 
-# Retries for each upload/chunk upload before abandoning
-MAX_RETRY = 3
+# Retries for each HTTP call on conection error
+MAX_RETRY = 5
+
+# Backoff factor between each retry
+# Ex: with 0.2 then sleep() will sleep for [0.2s, 0.4s, 0.8s, ...] between retries
+# Ex: with 1 then sleep() will sleep for [1s, 2s, 4s, ...] between retries
+RETRY_BACKOFF_FACTOR = 1
+
+# HTTP methods we want to handle in retries
+RETRY_METHODS = frozenset(['GET', 'POST', 'PUT', 'DELETE'])
+
+# HTTP status code to handle for retries
+RETRY_STATUS_CODES = [429, 500, 503, 504]
 
 # Size of chunks for the upload
 UPLOAD_CHUNK_SIZE = 20 * 1024 * 1024  # 20 MiB

--- a/nuxeo/exceptions.py
+++ b/nuxeo/exceptions.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 from __future__ import unicode_literals
 
+from requests.exceptions import RetryError
+
 from .compat import text
 
 try:
@@ -46,7 +48,7 @@ class CorruptedFile(NuxeoError):
         return repr(self)
 
 
-class HTTPError(NuxeoError):
+class HTTPError(RetryError, NuxeoError):
     """ Exception thrown when the server returns an error. """
     _valid_properties = {
         'status': None,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 import os
 
+import nuxeo.constants
+
 
 def setup_sentry():
     """ Setup Sentry. """
@@ -27,3 +29,6 @@ def setup_sentry():
 
 
 setup_sentry()
+
+# Speed-up testing by drastically reducing the backoff factor for retries
+nuxeo.constants.RETRY_BACKOFF_FACTOR = 0.01

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,4 +45,16 @@ def server():
                    auth=('Administrator', 'Administrator'),
                    cookies=cookies)
     server.client.set(schemas=['dublincore'])
+
+    # We do not need the retry feature in tests as it breaks too many uploads tests.
+    # But we will test that particular feature in one specific test.
+    server.client.disable_retry()
+
     return server
+
+
+@pytest.fixture(scope='function')
+def retry_server(server):
+    server.client.enable_retry()
+    yield server
+    server.client.disable_retry()

--- a/tests/test_batchupload.py
+++ b/tests/test_batchupload.py
@@ -249,7 +249,7 @@ def test_get_uploader(server):
             pass
 
 
-def test_uploaderror(server):
+def test_upload_error(server):
     batch = server.uploads.batch()
     file_in = 'test_in'
     with open(file_in, 'wb') as f:
@@ -281,8 +281,10 @@ def test_uploaderror(server):
             pass
 
 
-def test_upload_retry(server):
+def test_upload_retry(retry_server):
+    server = retry_server
     close_server = threading.Event()
+
     with SwapAttr(server.client, 'host', 'http://localhost:8081/nuxeo/'):
         try:
             serv = Server.upload_response_server(
@@ -316,7 +318,7 @@ def test_upload_resume(server):
                 wait_to_close_event=close_server,
                 port=8081,
                 requests_to_handle=20,
-                fail_args={'fail_at': 4, 'fail_number': 3}
+                fail_args={'fail_at': 4, 'fail_number': 1}
             )
             file_in = 'test_in'
 


### PR DESCRIPTION
Introduced several constants to allow customization:

- `MAX_RETRY` set to `5` (before it as used in upload and set to `3`).
- `RETRY_BACKOFF_FACTOR` set to `1` second.
- `RETRY_METHODS` set to `['GET', 'POST', 'PUT', 'DELETE']`.
- `RETRY_STATUS_CODES` set to `[429, 500, 503, 504]`.

And also, we have now `HTTPError` that inherits from `requests.exceptions.RetryError` and `NuxeoError`.

* NXPY-113: Use `requests.sessions.Session` rather than the deprecated `requests.session`.
* NXPY-114: Do not log the response of the CMIS endpoint (too long).