### PR TITLE
NXPY-126: Allow several callables for transfer callbacks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Release date: ``2019-xx-xx``
 - `NXPY-120 <https://jira.nuxeo.com/browse/NXPY-120>`__: Add a test for unavailable converters
 - `NXPY-121 <https://jira.nuxeo.com/browse/NXPY-121>`__: Do not log the response of the automation endpoint
 - `NXPY-123 <https://jira.nuxeo.com/browse/NXPY-123>`__: Pass the ``NXDRIVE_TEST_NUXEO_URL`` envar to tox
+- `NXPY-126 <https://jira.nuxeo.com/browse/NXPY-126>`__: Allow several callables for transfer callbacks
 
 Technical changes
 -----------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py3{4,5,6,7,8}
+envlist = py3{5,6,7,8}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Also removed Python 2.7 and 3.4 from tox envlist.