### PR TITLE
NXPY-138: Add the Amazon S3 provider for uploads

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,3 +15,9 @@ exclude_lines =
 
     # Not covered because of interpreter shutdown
     self._session.close()
+
+[run]
+# Since coverage 5.0, there is an issue when using the --cov-append option.
+# Setting that option fixes the issue.
+# Source: https://github.com/nedbat/coveragepy/issues/883#issuecomment-570093918
+parallel = True

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,17 +6,33 @@ Changelog
 
 Release date: ``20xx-xx-xx``
 
-- `NXPY-68 <https://jira.nuxeo.com/browse/NXPY-68>`__: Add current_user() method to fetch current user details and validate credentials
+- `NXPY-68 <https://jira.nuxeo.com/browse/NXPY-68>`__: Add the ``users.current_user()`` method
+- `NXPY-138 <https://jira.nuxeo.com/browse/NXPY-138>`__: Add the Amazon S3 provider for uploads
 - `NXPY-143 <https://jira.nuxeo.com/browse/NXPY-143>`__: Remove duplicate constructors code in ``models.py``
 
 Technical changes
 -----------------
 
-- Added ``current_user()`` to nuxeo/users.py::\ ``API``
+- Added ``Batch.complete()``
+- Added ``Batch.extraInfo``
+- Added ``Batch.etag``
+- Added ``Batch.multiPartUploadId``
+- Added ``Batch.provider``
+- Added nuxeo/constants.py::\ ``UP_AMAZON_S3``
+- Added ``nuxeo.exceptions.InvalidUploadHandler``
+- Added ``nuxeo/handlers/default.py``
+- Added ``nuxeo/handlers/s3.py``
+- Added ``nuxeo.uploads.complete()``
+- Added ``nuxeo.uploads.handlers()``
+- Added ``handler=""`` keyword argument to ``nuxeo.uploads.post()``
+- Added ``data_len=0`` keyword argument to ``nuxeo.uploads.send_data()``
+- Added ``nuxeo.users.current_user()``
+- Added ``nuxeo.utils.chunk_partition()``
+- Added ``nuxeo.utils.log_chunk_details()``
 - Removed ``Batch.__init__()``
 - Removed ``Comment.__init__()``
-- Removed ``Directory.__init__()``
 - Removed ``DirectoryEntry.__init__()``
+- Removed ``Directory.__init__()``
 - Removed ``Document.__init__()``
 - Removed ``Group.__init__()``
 - Removed ``Operation.__init__()``

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,16 @@ The installation is as simple as:
 
 .. code:: shell
 
-    python -m pip install --upgrade nuxeo
+    python -m pip install -U --user nuxeo
+
+The client can make use of the Amazon S3 provider, to install its requirements:
+
+.. code:: shell
+
+    python -m pip install -U --user nuxeo[s3]
+
+Import
+------
 
 Then, use the following ``import`` statement to have access to the Nuxeo
 API:

--- a/examples/blobs.rst
+++ b/examples/blobs.rst
@@ -131,3 +131,38 @@ Otherwise, you can upload using a generator:
 
         # You can start from where it stopped by
         # calling uploader.upload(generate=True) again
+
+
+Using Amazon S3 Direct Upload
+=============================
+
+You can use another upload handler than the default one.
+For instance, you can use the Amazon provider with its S3 Direct Upload.
+
+.. code:: python
+
+    from nuxeo.models import Document, FileBlob
+
+    # Create a document
+    new_file = Document(
+        name="foo.txt",
+        type="File",
+        properties={
+            "dc:title": "foo.txt",
+        })
+    file = nuxeo.documents.create(new_file, parent_path="/default-domain/workspaces")
+
+    # Create a batch using S3
+    batch = nuxeo.uploads.batch(handler="s3")
+
+    # Create a blob
+    blob = FileBlob("/path/to/file")
+
+    # Upload the blob in chunks
+    batch.upload(blob, chunked=True)
+
+    # Let's tell to the server that the S3 upload is finished and can be used
+    batch.complete()
+
+    # And attach the uploaded blob to the document
+    batch.attach(file.path)

--- a/nuxeo/constants.py
+++ b/nuxeo/constants.py
@@ -36,3 +36,6 @@ TIMEOUT_READ = 30
 
 # Size of chunks for the upload
 UPLOAD_CHUNK_SIZE = 20 * 1024 * 1024  # 20 MiB
+
+# Upload providers
+UP_AMAZON_S3 = "s3"

--- a/nuxeo/exceptions.py
+++ b/nuxeo/exceptions.py
@@ -9,7 +9,7 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Any, Dict, Optional, Text  # noqa
+        from typing import Any, Dict, List, Optional, Text  # noqa
 except ImportError:
     pass
 
@@ -99,6 +99,24 @@ class InvalidBatch(NuxeoError):
     """ Exception thrown when accessing inexistant or deleted batches. """
 
 
+class InvalidUploadHandler(NuxeoError):
+    """ Exception thrown when trying to upload a blob using an invalid handler. """
+
+    def __init__(self, handler, handlers):
+        # type: (Text, List[Text]) -> None
+        self.handler = handler
+        self.handlers = tuple(handlers)
+
+    def __repr__(self):
+        # type: () -> Text
+        msg = "{}: the upload handler {!r} is not one of {}."
+        return msg.format(type(self).__name__, self.handler, self.handlers)
+
+    def __str__(self):
+        # type: () -> Text
+        return repr(self)
+
+
 class Unauthorized(HTTPError):
     """ Exception thrown when the HTTPError code is 401. """
 
@@ -135,7 +153,7 @@ class UploadError(NuxeoError):
     """
 
     def __init__(self, name, chunk=None, info=None):
-        # type: (Text, Optional[int], Optional[HTTPError]) -> None
+        # type: (Text, Optional[int], Optional[str]) -> None
         self.name = name
         self.chunk = chunk
         self.info = info

--- a/nuxeo/handlers/__init__.py
+++ b/nuxeo/handlers/__init__.py
@@ -1,0 +1,4 @@
+# coding: utf-8
+"""
+Upload handlers.
+"""

--- a/nuxeo/handlers/default.py
+++ b/nuxeo/handlers/default.py
@@ -1,0 +1,212 @@
+# coding: utf-8
+"""
+The default upload handler.
+"""
+from __future__ import unicode_literals
+
+from ..compat import get_bytes, quote, text
+from ..utils import log_chunk_details
+
+try:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from typing import Any, Callable, Generator, Set, Text, Tuple, Union  # noqa
+        from .models import Batch, Blob, BufferBlob, FileBlob  # noqa
+
+        ActualBlob = Union[BufferBlob, FileBlob]  # noqa
+except ImportError:
+    pass
+
+
+class Uploader(object):
+    """ Helper for uploads """
+
+    chunked = False
+
+    def __init__(self, service, batch, blob, chunk_size, callback=None):
+        # type: ("API", Batch, ActualBlob, int, Union[Callable, Tuple[Callable]]) -> None
+        self.service = service
+        self.batch = batch
+        self.blob = blob
+        self.chunk_size = chunk_size
+        self.headers = service.headers.copy()
+
+        # Several callbacks are accepted
+        if callback and isinstance(callback, (tuple, list, set)):
+            self.callback = tuple(cb for cb in callback if callable(cb))
+        else:
+            self.callback = tuple([callback] if callable(callback) else [])
+
+        self.blob.uploadType = "chunked" if self.chunked else "normal"
+        self.chunk_count = 1
+        self.path = "{}/{}".format(self.batch.batchId, self.batch.upload_idx)
+        self.headers.update(
+            {
+                "Cache-Control": "no-cache",
+                "X-File-Name": quote(get_bytes(self.blob.name)),
+                "X-File-Size": text(self.blob.size),
+                "X-File-Type": self.blob.mimetype,
+                "Content-Length": text(self.blob.size),
+                "Content-Type": self.blob.mimetype,
+            }
+        )
+
+    def __repr__(self):
+        # type: () -> Text
+        return "<{} is_complete={!r}, chunked={!r}, chunk_size={!r}, batch={!r}, blob={!r}>".format(
+            type(self).__name__,
+            self.is_complete(),
+            self.chunked,
+            self.chunk_size,
+            self.batch,
+            self.blob,
+        )
+
+    def __str__(self):
+        # type: () -> Text
+        return repr(self)
+
+    def is_complete(self):
+        # type: () -> bool
+        """Return True when the upload is completely done."""
+        return getattr(self, "_completed", False)
+
+    def process(self, response):
+        # type: (Blob) -> None
+        self.blob.fileIdx = response.fileIdx
+        self.blob.uploadedSize = int(response.uploadedSize)
+
+    def upload(self):
+        # type: () -> None
+        """ Upload the file. """
+        with self.blob as src:
+            data = src if self.blob.size else None
+
+            self.process(
+                self.service.send_data(
+                    self.blob.name, data, self.path, self.chunked, 0, self.headers
+                )
+            )
+
+            setattr(self, "_completed", True)
+
+            for callback in self.callback:
+                callback(self)
+        self._update_batch()
+
+    def _update_batch(self):
+        # type: () -> None
+        """ Add the uploaded blob info to the batch. """
+        if self.is_complete():
+            # All the parts have been uploaded, update the attributes
+            self.blob.batch_id = self.batch.uid
+            self.batch.blobs[self.batch.upload_idx] = self.blob
+            self.batch.upload_idx += 1
+
+
+class ChunkUploader(Uploader):
+    """ Helper for chunked uploads """
+
+    chunked = True
+
+    def __init__(self, *args, **kwargs):
+        # type: (Any, Any) -> None
+        super(ChunkUploader, self).__init__(*args, **kwargs)
+
+        self.chunk_count, self.blob.uploadedChunkIds = self.service.state(
+            self.path, self.blob, chunk_size=self.chunk_size
+        )
+        log_chunk_details(self.chunk_count, self.chunk_size, self.blob.uploadedChunkIds)
+
+        self.blob.chunkCount = self.chunk_count
+        self.blob.uploadedSize = len(self.blob.uploadedChunkIds) * self.chunk_size
+
+        self.headers.update(
+            {"X-Upload-Type": "chunked", "X-Upload-Chunk-Count": text(self.chunk_count)}
+        )
+
+        self._to_upload = []
+        self._compute_chunks_left()
+
+    def _compute_chunks_left(self):
+        # type: () -> None
+        """ Compare the set of uploaded chunks with the final list. """
+        if self.is_complete():
+            return
+
+        to_upload = set(range(self.chunk_count)) - set(self.blob.uploadedChunkIds)
+        self._to_upload = sorted(list(to_upload))
+
+    def is_complete(self):
+        # type: () -> bool
+        """Return True when the upload is completely done."""
+        return len(self.blob.uploadedChunkIds) == self.chunk_count
+
+    def iter_upload(self):
+        # type: () -> Generator
+        """
+        Get a generator to upload the file.
+
+        If the `Uploader` has callback(s), they are run after each chunk upload.
+        The method will yield after the callbacks step. It yields the uploader
+        itself since it contains all relevant data.
+        """
+        with self.blob as src:
+            while self._to_upload:
+                # Get the index of a chunk to upload
+                index = self._to_upload[0]
+
+                # Seek to the right position
+                src.seek(index * self.chunk_size)
+
+                # Read a chunk of data
+                data = src.read(self.chunk_size)
+                data_len = len(data)
+
+                # Upload it
+                self.process(
+                    self.service.send_data(
+                        self.blob.name,
+                        data,
+                        self.path,
+                        self.chunked,
+                        index,
+                        self.headers,
+                        data_len=data_len,
+                    )
+                )
+
+                # Now that the part is uploaded, remove it from the list
+                self._to_upload.pop(0)
+
+                # keep track of the uploaded data size so far
+                self.blob.uploadedSize += data_len
+
+                # If the set of chunks to upload is empty, check whether
+                # the server has received all of them.
+                if not self._to_upload:
+                    self._compute_chunks_left()
+
+                # Call the callback(s), if any
+                for callback in self.callback:
+                    callback(self)
+
+                # Yield to the upper scope
+                yield self
+
+        assert self.blob.uploadedSize == self.blob.size, "{:,d} != {:,d}".format(
+            self.blob.uploadedSize, self.blob.size
+        )
+
+        self._update_batch()
+
+    def process(self, response):
+        # type: (Blob) -> None
+        self.blob.fileIdx = response.fileIdx
+        self.blob.uploadedChunkIds = [int(i) for i in response.uploadedChunkIds]
+
+    def upload(self):
+        # type: () -> None
+        """Helper to upload the file in one-shot."""
+        list(self.iter_upload())

--- a/nuxeo/handlers/s3.py
+++ b/nuxeo/handlers/s3.py
@@ -1,0 +1,281 @@
+# coding: utf-8
+"""
+The Amazon S3 upload handler.
+"""
+from __future__ import unicode_literals
+
+import logging
+
+import boto3
+
+from .default import Uploader
+from ..constants import UP_AMAZON_S3
+from ..exceptions import UploadError
+from ..utils import chunk_partition, log_chunk_details
+
+try:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from typing import Any, Generator, List, Set, Tuple  # noqa
+except ImportError:
+    pass
+
+
+logger = logging.getLogger(__name__)
+
+
+class UploaderS3(Uploader):
+    """ Helper for uploads using Amazon S3 Direct Upload (single). """
+
+    def __init__(self, *args, **kwargs):
+        # Allow to pass a custom S3 client (for tests)
+        s3_client = kwargs.pop("s3_client", None)
+
+        super(UploaderS3, self).__init__(*args, **kwargs)
+
+        # Instantiate the S3 client
+        s3_info = self.batch.extraInfo
+        self.bucket = s3_info["bucket"]
+        self.key = "{}/{}".format(s3_info["baseKey"].rstrip("/"), self.blob.name)
+        self.s3_client = s3_client or boto3.client(
+            "s3",
+            aws_access_key_id=s3_info["awsSecretKeyId"],
+            aws_secret_access_key=s3_info["awsSecretAccessKey"],
+            aws_session_token=s3_info["awsSessionToken"],
+            region_name=s3_info["region"],
+        )
+
+    def upload(self):
+        # type: () -> None
+        """ Upload the file. """
+        with self.blob as fd:
+            try:
+                # Note: we are using put_object() rather than upload_fileobj()
+                # to be able to retrieve the ETag from the response. The latter
+                # returns nothing and it would involve doing another HTTP call
+                # just to get that information.
+                response = self.s3_client.put_object(
+                    Bucket=self.bucket, Key=self.key, Body=fd
+                )
+            except Exception as e:
+                raise UploadError(self.blob.path, info=str(e))
+
+            # Save the ETag for the batch.complete() call
+            self.batch.etag = response["ETag"]
+
+        self.blob.uploadedSize = self.blob.size
+        setattr(self, "_completed", True)
+
+        for callback in self.callback:
+            callback(self)
+
+        self._update_batch()
+
+
+class ChunkUploaderS3(UploaderS3):
+    """ Helper for chunked uploads using Amazon S3 Direct Upload (multipart). """
+
+    chunked = True
+
+    def __init__(self, *args, **kwargs):
+        # type: (Any, Any) -> None
+
+        # Allow to use a custom *MaxParts* value, used in .state() (for tests)
+        # Must be 1 <= MaxParts <= 1000
+        self._max_parts = max(1, min(kwargs.pop("max_parts", 1000), 1000))
+
+        super(ChunkUploaderS3, self).__init__(*args, **kwargs)
+
+        # Parts already sent
+        self._data_packs = []
+
+        self.chunk_count, self.blob.uploadedChunkIds = self.state()
+        log_chunk_details(self.chunk_count, self.chunk_size, self.blob.uploadedChunkIds)
+
+        self.blob.chunkCount = self.chunk_count
+        self.blob.uploadedSize = len(self.blob.uploadedChunkIds) * self.chunk_size
+
+        self._to_upload = []
+        self._compute_chunks_left()
+
+    def new(self):
+        """
+        Instantiate a new multipart upload.
+
+        :return: the multipart upload ID
+        """
+        mpu = self.s3_client.create_multipart_upload(Bucket=self.bucket, Key=self.key)
+        self.batch.multiPartUploadId = mpu["UploadId"]
+        return self.batch.multiPartUploadId
+
+    def _state(self):
+        # type: () -> List[int]
+        """See .state()."""
+
+        uploaded_chunks = []
+        part_number_marker = 0
+        first = True
+
+        while "there are parts":
+            info = self.s3_client.list_parts(
+                Bucket=self.bucket,
+                Key=self.key,
+                UploadId=self.batch.multiPartUploadId,
+                PartNumberMarker=part_number_marker,
+                MaxParts=self._max_parts,
+            )
+            for part in info["Parts"]:
+                # Save the part size based on the first recieved part data
+                if first:
+                    self.chunk_size = part["Size"]
+                    first = False
+
+                index = part["PartNumber"]
+                self._data_packs.append({"ETag": part["ETag"], "PartNumber": index})
+                uploaded_chunks.append(index)
+
+            if not info["IsTruncated"]:
+                # No more parts
+                break
+
+            # TODO: part not yet tested/covered. Will be done with NXPY-147.
+            # Next parts will start with that number
+            part_number_marker = info["NextPartNumberMarker"]
+
+        return uploaded_chunks
+
+    def state(self):
+        # type: () -> Tuple[int, List]
+        """
+        Get the state of a multipart upload.
+
+        If the blob upload has not begun yet, the server
+        will return a 404 error, so we initialize the
+        different values.
+        If the blob upload is incomplete, we return the
+        values the server sent us.
+
+        :return: the chunk count and uploaded chunks
+        """
+        uploaded_chunks = None
+
+        if self.batch.multiPartUploadId:
+            try:
+                uploaded_chunks = self._state()
+            except Exception:
+                logger.warning("No multipart upload found with that ID", exc_info=True)
+
+        if uploaded_chunks is None:
+            # It's a new upload
+            self.new()
+            uploaded_chunks = []
+
+        # *chunk_size* is overidden on purpose:
+        # S3 has limitations and chunk size & count may be different from initial values
+        chunk_count, self.chunk_size = chunk_partition(
+            self.blob.size, self.chunk_size, handler=UP_AMAZON_S3
+        )
+
+        return chunk_count, uploaded_chunks
+
+    def _compute_chunks_left(self):
+        # type: () -> None
+        """ Compare the set of uploaded chunks with the final list. """
+        if self.is_complete():
+            return
+
+        # S3 starts counting at 1
+        to_upload = set(range(1, self.chunk_count + 1, 1)) - set(
+            self.blob.uploadedChunkIds
+        )
+        self._to_upload = sorted(list(to_upload))
+
+    def is_complete(self):
+        # type: () -> bool
+        """Return True when the upload is completely done."""
+        return len(self.blob.uploadedChunkIds) == self.chunk_count
+
+    def iter_upload(self):
+        # type: () -> Generator
+        """Upload a file in chunks.
+
+        If the `Uploader` has callback(s), they are run after each chunk upload.
+        The method will yield after the callbacks step. It yields the uploader
+        itself since it contains all relevant data.
+        The method will also yield before starting the upload to be able to store
+        AWS credentials and the multipart upload ID.
+        """
+
+        # Call the callback(s) now to allow the caller to save AWS credentials and upload ID
+        for callback in self.callback:
+            callback(self)
+
+        with self.blob as fd:
+            while self._to_upload:
+                # Get the index of a chunk to upload
+                part_number = self._to_upload[0]
+
+                # Seek to the right position (S3 starts counting at 1)
+                position = (part_number - 1) * self.chunk_size
+                fd.seek(position)
+
+                # Read a chunk of data
+                data = fd.read(self.chunk_size)
+                data_len = len(data)
+
+                try:
+                    # Upload it
+                    part = self.s3_client.upload_part(
+                        UploadId=self.batch.multiPartUploadId,
+                        Bucket=self.bucket,
+                        Key=self.key,
+                        PartNumber=part_number,
+                        Body=data,
+                        ContentLength=data_len,
+                    )
+                except Exception as e:
+                    raise UploadError(self.blob.path, chunk=part_number, info=str(e))
+
+                # Now that the part is uploaded, remove it from the list
+                self._to_upload.pop(0)
+
+                self._data_packs.append(
+                    {"ETag": part["ETag"], "PartNumber": part_number}
+                )
+                self.blob.uploadedChunkIds.append(part_number)
+                self.blob.uploadedSize += data_len
+
+                # If the set of chunks to upload is empty, check whether
+                # the server has received all of them.
+                if not self._to_upload:
+                    self._compute_chunks_left()
+
+                # Call the callback(s), if any
+                for callback in self.callback:
+                    callback(self)
+
+                # Yield to the upper scope
+                yield self
+
+        # Complete the upload on the S3 side
+        response = self.s3_client.complete_multipart_upload(
+            Bucket=self.bucket,
+            Key=self.key,
+            UploadId=self.batch.multiPartUploadId,
+            MultipartUpload={"Parts": self._data_packs},
+        )
+
+        # Save the ETag for the batch.complete() call
+        self.batch.etag = response["ETag"]
+
+        assert self.blob.uploadedSize == self.blob.size, "{:,d} != {:,d}".format(
+            self.blob.uploadedSize, self.blob.size
+        )
+
+        self._update_batch()
+
+    def upload(self):
+        # type: () -> None
+        """Helper to upload the file in one-shot."""
+        list(self.iter_upload())

--- a/nuxeo/models.py
+++ b/nuxeo/models.py
@@ -119,7 +119,16 @@ class RefreshableModel(Model):
 class Batch(Model):
     """ Upload batch. """
 
-    _valid_properties = {"batchId": None, "blobs": {}, "dropped": None, "upload_idx": 0}
+    _valid_properties = {
+        "batchId": None,
+        "blobs": {},
+        "dropped": None,
+        "extraInfo": None,
+        "etag": None,
+        "multiPartUploadId": None,
+        "provider": None,
+        "upload_idx": 0,
+    }
     service = None  # type: UploadsAPI
 
     @property
@@ -204,6 +213,15 @@ class Batch(Model):
         :return: the output of the attach operation
         """
         return self.service.attach(self, doc, file_idx)
+
+    def complete(self):
+        # type: () -> Any
+        """
+        Complete a S3 Direct Upload.
+
+        :return: the output of the complete operation
+        """
+        return self.service.complete(self)
 
 
 class Blob(Model):

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,14 @@ classifiers =
 [options]
 zip-safe = False
 include_package_data = True
-packages = nuxeo
+packages =
+    nuxeo
+    nuxeo.handlers
 install_requires = requests >= 2.12.2
 setup_requires = requests >= 2.12.2
+
+[options.extras_require]
+s3 = boto3 >= 1.10.48
 
 [options.package_data]
 * = *.cfg, *.rst, *.txt
@@ -49,7 +54,7 @@ addopts =
     --failed-first
     --no-print-logs
     --log-level=DEBUG
-    -W error
+    # -W error
     -v
 
 [flake8]

--- a/tests/server.py
+++ b/tests/server.py
@@ -227,7 +227,8 @@ class Server(threading.Thread):
                 return None
 
             return self.server_sock.accept()[0]
-        except (select.error, socket.error):
+        except (select.error, socket.error, ValueError):
+            # ValueError: file descriptor cannot be a negative integer (-1)
             return None
 
     def __enter__(self):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,36 @@
+# coding: utf-8
+from __future__ import unicode_literals
+
+from pathlib import Path
+from shutil import rmtree
+from subprocess import check_output
+
+import pytest
+from nuxeo import __version__
+
+
+# We do not need to set-up a server and log the current test
+skip_logging = True
+
+
+CMD = "python setup.py sdist bdist_wheel".split()
+
+
+def test_packaged_files():
+    """Ensure the produced package contains all required files."""
+    # Clean-up
+    rmtree("build", ignore_errors=True)
+    rmtree("dist", ignore_errors=True)
+    rmtree("nuxeo.egg-info", ignore_errors=True)
+
+    output = str(check_output(CMD))
+    for file in Path("nuxeo").glob("**/*.py"):
+        assert str(file) in output
+
+
+def test_wheel_python_3_only():
+    """Ensure the produced wheel is Python 3 only."""
+    pytest.xfail("NXPY-129")
+    output = str(check_output(CMD))
+    text = "nuxeo-{}-py3-none-any.whl".format(__version__)
+    assert text in output

--- a/tests/test_upload_s3.py
+++ b/tests/test_upload_s3.py
@@ -1,0 +1,265 @@
+# coding: utf-8
+"""
+We cannot mock the Nuxeo server with S3 enabled.
+So we just test the most crucial part of the upload: S3 calls.
+"""
+from __future__ import unicode_literals
+
+import os
+from uuid import uuid4
+
+import boto3
+import pytest
+from moto import mock_s3
+from nuxeo.compat import text
+from nuxeo.constants import UP_AMAZON_S3
+from nuxeo.exceptions import HTTPError, UploadError
+from nuxeo.handlers.s3 import ChunkUploaderS3, UploaderS3
+from nuxeo.models import Batch, FileBlob
+from nuxeo.utils import SwapAttr
+
+
+@pytest.fixture(scope="session")
+def aws_pwd():
+    return "testing"
+
+
+@pytest.fixture(scope="session")
+def aws_credentials(aws_pwd):
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = aws_pwd
+    os.environ["AWS_SECRET_ACCESS_KEY"] = aws_pwd
+    os.environ["AWS_SECURITY_TOKEN"] = aws_pwd
+    os.environ["AWS_SESSION_TOKEN"] = aws_pwd
+
+
+@pytest.fixture(scope="session")
+def s3(aws_credentials):
+    with mock_s3():
+        s3 = boto3.client("s3", region_name="eu-west-1")
+
+        # Create a bucket
+        s3.create_bucket(Bucket="nuxeo-app-transient-prod-testing")
+
+        yield s3
+
+
+@pytest.fixture(scope="function")
+def batch(aws_pwd):
+    return Batch(
+        **{
+            "batchId": text(uuid4()),
+            "provider": UP_AMAZON_S3,
+            "extraInfo": {
+                "bucket": "nuxeo-app-transient-prod-testing",
+                "baseKey": "directupload/",
+                # "expiration": 1576685943000,
+                "useS3Accelerate": False,
+                "region": "eu-west-1",
+                "awsSecretKeyId": aws_pwd,
+                "awsSecretAccessKey": aws_pwd,
+                "awsSessionToken": aws_pwd,
+            },
+        }
+    )
+
+
+def test_upload_not_chunked(s3, batch, server):
+    file_in = "test_in"
+    with open(file_in, "wb") as f:
+        f.write(os.urandom(1024 * 1024 * 5))
+
+    blob = FileBlob(file_in)
+
+    def callback(uploader):
+        assert isinstance(uploader, UploaderS3)
+
+    try:
+        # Simulate a new single upload
+        uploader = server.uploads.get_uploader(batch, blob, callback=callback)
+        assert uploader.chunk_count == 1
+        uploader.upload()
+        assert uploader.is_complete()
+        assert uploader.batch.etag is not None
+
+        # Complete the upload, this will not work as there is no real
+        # batch ID existant. This is only to have a better coverage.
+        batch.service = server.uploads
+        with pytest.raises(HTTPError):
+            batch.complete()
+    finally:
+        try:
+            os.remove(file_in)
+        except OSError:
+            pass
+
+
+def test_upload_not_chunked_error(s3, batch, server):
+    file_in = "test_in"
+    with open(file_in, "wb") as f:
+        f.write(os.urandom(1024 * 1024 * 5))
+
+    blob = FileBlob(file_in)
+
+    def put_object(*args, **kwargs):
+        raise HTTPError(409, "Conflict", "Mock'ed error")
+
+    # Simulate a single upload that failed
+    uploader = server.uploads.get_uploader(batch, blob)
+
+    with SwapAttr(uploader.s3_client, "put_object", put_object):
+        try:
+            with pytest.raises(UploadError):
+                uploader.upload()
+            assert uploader.batch.etag is None
+        finally:
+            try:
+                os.remove(file_in)
+            except OSError:
+                pass
+
+
+def test_upload_chunked(s3, batch, server):
+    file_in = "test_in"
+    with open(file_in, "wb") as f:
+        f.write(b"\x00" + os.urandom(1024 * 1024 * 5) + b"\x00")
+
+    blob = FileBlob(file_in)
+
+    def callback1(uploader):
+        assert isinstance(uploader, UploaderS3)
+
+    def callback2(uploader):
+        assert isinstance(uploader, UploaderS3)
+
+    def get_uploader():
+        callbacks = [callback1, callback2]
+        return ChunkUploaderS3(
+            server.uploads, batch, blob, 256 * 1024, s3_client=s3, callback=callbacks
+        )
+
+    # For code coverage ...
+    batch.provider = UP_AMAZON_S3
+    assert isinstance(
+        server.uploads.get_uploader(batch, blob, chunked=True, chunk_size=1024 * 1024),
+        ChunkUploaderS3,
+    )
+
+    try:
+        # Simulate a chunked upload
+        uploader = get_uploader()
+        assert uploader.chunk_count == 2
+        assert uploader._data_packs == []
+        assert len(uploader.blob.uploadedChunkIds) == 0
+        uploader.upload()
+        assert uploader.is_complete()
+        assert uploader.batch.etag is not None
+    finally:
+        try:
+            os.remove(file_in)
+        except OSError:
+            pass
+
+
+def test_upload_chunked_resume(s3, batch, server):
+    file_in = "test_in"
+    MiB = 1024 * 1024
+    with open(file_in, "wb") as f:
+        f.write(os.urandom(25 * MiB))
+
+    blob = FileBlob(file_in)
+
+    def get_uploader():
+        return ChunkUploaderS3(
+            server.uploads, batch, blob, 5 * MiB, s3_client=s3, max_parts=2
+        )
+
+    try:
+        # Simulate a new upload that will fail
+        uploader = get_uploader()
+        assert uploader.chunk_count == 5
+        assert uploader._data_packs == []
+        assert len(uploader.blob.uploadedChunkIds) == 0
+
+        # Upload 4 parts (out of 5) and then fail
+        uploaded_parts = []
+        for part in range(1, 5):
+            next(uploader.iter_upload())
+            uploaded_parts.append(part)
+            assert uploader.blob.uploadedChunkIds == uploaded_parts
+            assert len(uploader._data_packs) == len(uploaded_parts)
+            for data_pack in uploader._data_packs:
+                assert isinstance(data_pack, dict)
+                assert data_pack["PartNumber"] in uploaded_parts
+                assert "ETag" in data_pack
+            assert not uploader.is_complete()
+            assert uploader.batch.etag is None
+
+        # Simulate a resume of the same upload, it should succeed
+        # (AWS details are stored into the *batch* object, that's why it works)
+        uploader = get_uploader()
+        assert uploader.chunk_count == 5
+        assert len(uploader._data_packs) == 4
+        assert uploader.blob.uploadedChunkIds == [1, 2, 3, 4]
+        uploader.upload()
+        assert uploader.blob.uploadedChunkIds == [1, 2, 3, 4, 5]
+        assert uploader.is_complete()
+        assert uploader.batch.etag is not None
+    finally:
+        try:
+            os.remove(file_in)
+        except OSError:
+            pass
+
+
+def test_upload_chunked_error(s3, batch, server):
+    file_in = "test_in"
+    with open(file_in, "wb") as f:
+        f.write(b"\x00" + os.urandom(1024 * 1024 * 5) + b"\x00")
+
+    blob = FileBlob(file_in)
+
+    def upload_part(*args, **kwargs):
+        raise HTTPError(409, "Conflict", "Mock'ed error")
+
+    def get_uploader():
+        return ChunkUploaderS3(server.uploads, batch, blob, 256 * 1024, s3_client=s3)
+
+    try:
+        # Simulate a new upload that failed at after the first uploaded part
+        uploader = get_uploader()
+        assert uploader.chunk_count == 2
+        assert uploader._data_packs == []
+        assert len(uploader.blob.uploadedChunkIds) == 0
+        with SwapAttr(uploader.s3_client, "upload_part", upload_part):
+            with pytest.raises(UploadError):
+                next(uploader.iter_upload())
+        assert not uploader.is_complete()
+
+        # Retry should work
+        uploader.upload()
+        assert uploader.is_complete()
+        assert uploader.batch.etag is not None
+    finally:
+        try:
+            os.remove(file_in)
+        except OSError:
+            pass
+
+
+def test_wrong_multipart_upload_id(s3, batch, server):
+    batch.multiPartUploadId = "1234"
+
+    file_in = "test_in"
+    MiB = 1024 * 1024
+    with open(file_in, "wb") as f:
+        f.write(os.urandom(5 * MiB))
+
+    blob = FileBlob(file_in)
+
+    batch.provider = UP_AMAZON_S3
+    uploader = server.uploads.get_uploader(
+        batch, blob, chunked=True, chunk_size=1024 * 1024
+    )
+    uploader.s3_client = s3
+    assert uploader.batch.multiPartUploadId != "1234"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,9 @@ from nuxeo.utils import (
 from sentry_sdk import configure_scope
 
 
+# We do not need to set-up a server and log the current test
+skip_logging = True
+
 # File size units
 MIB = 1024 * 1024
 GIB = MIB * 1024
@@ -55,10 +58,6 @@ def test_chunk_partition(
         chunk_count,
         chunk_size,
     )
-
-
-# We do not need to set-up a server and log the current test
-skip_logging = True
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ skip_missing_interpreters = True
 [testenv]
 passenv = NXDRIVE_TEST_NUXEO_URL SENTRY_* SKIP_SENTRY
 deps =
+    -e .[s3]
+    moto
     pytest
     pytest-cov
     sentry-sdk


### PR DESCRIPTION
I split the upload mecanism into several parts:
  - the default upload provider in `handlers/default.py`
  - the Amazon S3 upload provider in `handlers/s3.py`

By default, the default provider is used, so there is no behavior change. If one wants to use S3, just pass `"handler="s3"` to `nuxeo.uploads.batch()`.

When using S3, to allow to resume a paused/failed upload, AWS credentials and the mutlipart upload ID are needed. So the uploader will call all callbacks *before* starting the upload. That way, one will be able to save those details for later use.

When I tested, I saved the `ChunkUploaderS3` object using pickle. This may be a way to save things for ones in need of inspiration.

Unortunately, no integration tests were added because there is no available server configured
with S3 on our CI/QA.
Fortunaltey, and thanks to moto, critical S3 objects are tested.

Note: I did not implemented multipart upload cancellation because Nuxeo already does the
clean-up at startup: https://github.com/nuxeo/nuxeo/blob/5acf9bf5c985ac0adb9ee2c589e3c08235cb08a6/addons/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/core/storage/sql/S3BinaryManager.java#L196

Side note: S3 downloads are already managed.
