### PR TITLE
NXPY-131: Make the HTTP response logging safer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 Release date: ``2019-xx-xx``
 
+- `NXPY-131 <https://jira.nuxeo.com/browse/NXPY-131>`__: Make the HTTP response logging safer
 - `NXPY-141 <https://jira.nuxeo.com/browse/NXPY-141>`__: Add the Comments API
 
 Technical changes

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nuxeo
-version = 2.2.4
+version = 2.3.0
 author = Nuxeo
 author-email = maintainers-python@nuxeo.com
 description = Nuxeo REST API Python client
@@ -48,7 +48,7 @@ addopts =
     --showlocals
     --failed-first
     --no-print-logs
-    --log-level=CRITICAL
+    --log-level=DEBUG
     -W error
     -v
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,11 @@ logging.basicConfig(
 
 @pytest.fixture(scope="function", autouse=True)
 def server_log(request, server):
+    # To skip that fixture, define *skip_logging* at the top of the test file
+    should_log_to_server = getattr(request.module, "skip_logging", False)
+    if should_log_to_server:
+        return
+
     msg = ">>> testing: {}.{}".format(
         request.module.__name__, request.function.__name__
     )

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,6 +1,10 @@
 from nuxeo.exceptions import Forbidden, HTTPError, Unauthorized
 
 
+# We do not need to set-up a server and log the current test
+skip_logging = True
+
+
 def test_crafted_forbidden():
     exc = Forbidden()
     assert exc.status == 403

--- a/tests/test_log_response.py
+++ b/tests/test_log_response.py
@@ -1,0 +1,136 @@
+# coding: utf-8
+"""
+Test NuxeoClient._log_response() to prevent regressions causing memory errors.
+requests Responses objects are crafted based on real usecases that broke something at some point.
+"""
+import logging
+
+import pytest
+from requests import Response
+from nuxeo.client import NuxeoClient
+
+
+# We do not need to set-up a server and log the current test
+skip_logging = True
+
+
+class ResponseEmpty(Response):
+    def __init__(self):
+        super().__init__()
+        self.url = "http://localhost:8080/nuxeo/nothing"
+
+
+class ResponseAutomation(Response):
+    def __init__(self):
+        super().__init__()
+        self.headers["content-type"] = "application/json"
+        self.headers["content-length"] = "1024"
+        self.url = "http://localhost:8080/nuxeo/site/automation"
+
+
+class ResponseCmis(Response):
+    def __init__(self):
+        super().__init__()
+        self.headers["content-type"] = "application/json"
+        self.headers["content-length"] = "1024"
+        self.url = "http://localhost:8080/nuxeo/json/cmis"
+
+
+class ResponseMov(Response):
+    def __init__(self):
+        super().__init__()
+        self.headers["content-type"] = "video/quicktime"
+        self.headers["content-length"] = 1088996060
+        self.url = "http://localhost:8080/nuxeo/1.0%20GiB.mov"
+
+    @property
+    def content(self):
+        raise MemoryError()
+
+
+class ResponseIso(Response):
+    def __init__(self):
+        super().__init__()
+        self.headers["content-type"] = "application/octet-stream"
+        self.headers["content-length"] = "734334976"
+        self.url = "http://localhost:8080/nuxeo/700.3%20MiB.iso"
+
+    @property
+    def content(self):
+        raise MemoryError()
+
+
+class ResponseMxf(Response):
+    def __init__(self):
+        super().__init__()
+        self.headers["content-type"] = "application/mxf"
+        self.headers["content-length"] = "8932294324"
+        self.url = "http://localhost:8080/nuxeo/8.3%20GiB.mxf"
+
+    @property
+    def content(self):
+        raise OverflowError("join() result is too long")
+
+
+class ResponseTextOk(Response):
+    def __init__(self):
+        super().__init__()
+        self.headers["content-type"] = "text/plain"
+        self.headers["content-length"] = "1024"
+        self.url = "http://localhost:8080/nuxeo/small%20file.txt"
+
+    @property
+    def content(self):
+        return "TADA!".encode("utf-8")
+
+
+class ResponseTextError(Response):
+    def __init__(self):
+        super().__init__()
+        self.headers["content-type"] = "text/plain"
+        self.headers["content-length"] = "1024"
+        self.url = "http://localhost:8080/nuxeo/big%20file.txt"
+
+    @property
+    def content(self):
+        raise MemoryError()
+
+
+class ResponseTextTooLong(Response):
+    def __init__(self):
+        super().__init__()
+        self.headers["content-type"] = "text/plain"
+        self.headers["content-length"] = 4096 * 2
+        self.url = "http://localhost:8080/nuxeo/big%20file.txt"
+
+
+@pytest.mark.parametrize(
+    "response, pattern",
+    [
+        (ResponseEmpty, "no content"),
+        (ResponseAutomation, "Automation details"),
+        (ResponseCmis, "CMIS details"),
+        (ResponseMov, "binary data"),
+        (ResponseMxf, "binary data"),
+        (ResponseIso, "binary data"),
+        (ResponseTextOk, "TADA!"),
+        (ResponseTextTooLong, "too much text"),
+        (ResponseTextError, "no enough memory"),
+    ],
+)
+def test_response(caplog, response, pattern):
+    """Test all kind of responses to cover the whole method."""
+    caplog.clear()
+    NuxeoClient._log_response(response(), 4096)
+
+    assert caplog.records
+    for record in caplog.records:
+        assert record.levelname == "DEBUG"
+        assert pattern in record.message
+
+
+def test_response_with_logger_not_in_debug(caplog):
+    """If the logging level is higher than DEBUG, nothing is logged."""
+    with caplog.at_level(logging.INFO):
+        NuxeoClient._log_response(ResponseEmpty(), 4096)
+    assert not caplog.records

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,10 @@ from sentry_sdk import configure_scope
 from nuxeo.utils import SwapAttr, get_digester, guess_mimetype
 
 
+# We do not need to set-up a server and log the current test
+skip_logging = True
+
+
 @pytest.mark.parametrize(
     "hash, digester",
     [


### PR DESCRIPTION
Now, no excuses: we cannot have `MemoryError` nor `OverflowError` anymore. The HTTP response
logger is safe to use.

I also added a simple module attribute `skip_logging` to define to `True` in test files where we do not need to log the current test on the server. This will prevent having to create a connection to the server for nothing.