### PR TITLE
NXPY-68: Add the users.current_user() method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,11 +6,13 @@ Changelog
 
 Release date: ``20xx-xx-xx``
 
+- `NXPY-68 <https://jira.nuxeo.com/browse/NXPY-68>`__: Add current_user() method to fetch current user details and validate credentials
 - `NXPY-143 <https://jira.nuxeo.com/browse/NXPY-143>`__: Remove duplicate constructors code in ``models.py``
 
 Technical changes
 -----------------
 
+- Added ``current_user()`` to nuxeo/users.py::\ ``API``
 - Removed ``Batch.__init__()``
 - Removed ``Comment.__init__()``
 - Removed ``Directory.__init__()``

--- a/nuxeo/users.py
+++ b/nuxeo/users.py
@@ -61,3 +61,17 @@ class API(APIEndpoint):
         :param user_id: the id of the user to delete
         """
         super(API, self).delete(user_id)
+
+    def current_user(self):
+        # type: () -> User
+        """
+        Get the current user details and validate the connection to the server at the same time.
+
+        :return User: user's details
+        """
+        details = self.client.request("POST", "site/automation/login").json()
+        return User(
+            extendedGroups=details["groups"],
+            id=details["username"],
+            isAdministrator=details["isAdministrator"],
+        )

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -43,6 +43,14 @@ def test_create_wrong_arguments(server):
         server.users.create(1)
 
 
+def test_current_user(server):
+    user = server.users.current_user()
+    assert isinstance(user, User)
+    assert user.uid == "Administrator"
+    assert "administrators" in user.extendedGroups
+    assert user.isAdministrator
+
+
 def test_fetch(server):
     user = server.users.get("Administrator")
     assert user


### PR DESCRIPTION
To fetch current user details and validate credentials.

Note: at first I would have call the new method when initializing the client, but it would break Nuxeo
Drive when credentials are obsoletes. So there is just a new method and developers are free to call it.