### PR TITLE
NXPY-149: Add Batch.is_s3() helper

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,12 +6,12 @@ Changelog
 
 Release date: ``2020-xx-xx``
 
-- `NXPY- <https://jira.nuxeo.com/browse/NXPY->`__:
+- `NXPY-149 <https://jira.nuxeo.com/browse/NXPY-149>`__: Add ``Batch.is_s3()`` helper
 
 Technical changes
 -----------------
 
--
+- Added ``Batch.is_s3()``
 
 2.4.0
 -----

--- a/nuxeo/handlers/s3.py
+++ b/nuxeo/handlers/s3.py
@@ -216,9 +216,8 @@ class ChunkUploaderS3(UploaderS3):
         AWS credentials and the multipart upload ID.
         """
 
-        # Call the callback(s) now to allow the caller to save AWS credentials and upload ID
-        for callback in self.callback:
-            callback(self)
+        # Yield now to allow the caller to save AWS credentials and the MPU ID
+        yield self
 
         with self.blob as fd:
             while self._to_upload:

--- a/nuxeo/models.py
+++ b/nuxeo/models.py
@@ -5,6 +5,7 @@ import os
 from io import StringIO
 
 from .compat import text
+from .constants import UP_AMAZON_S3
 from .exceptions import InvalidBatch
 from .utils import guess_mimetype
 
@@ -179,6 +180,11 @@ class Batch(Model):
         :return: the uploader
         """
         return self.service.get_uploader(self, blob, **kwargs)
+
+    def is_s3(self):
+        # type: () -> bool
+        """Return True if the upload provider is Amazon S3."""
+        return self.provider == UP_AMAZON_S3
 
     def upload(self, blob, **kwargs):
         # type: (Blob, Any) -> Blob


### PR DESCRIPTION
Also aligned `ChunkUploaderS3.iter_upload()` on its own docstring: it now yields itself before starting uploading contents.
Before the patch, callbacks were called and this was really not helpful nor practical from outside the client.