### PR TITLE
NXPY-155: Don't use dots or underscores in custom HTTP headers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Release date: ``2020-xx-xx``
 
 - `NXPY-148 <https://jira.nuxeo.com/browse/NXPY-148>`__: Use the tmp_path fixture to auto-cleanup created files in tests
-- `NXPY-155 <https://jira.nuxeo.com/browse/NXPY-155>`__: Don't use dots in custom HTTP headers
+- `NXPY-155 <https://jira.nuxeo.com/browse/NXPY-155>`__: Don't use dots or underscores in custom HTTP headers
 - `NXPY-156 <https://jira.nuxeo.com/browse/NXPY-156>`__: Do not silence S3 errors on upload resuming
 - `NXPY-158 <https://jira.nuxeo.com/browse/NXPY-158>`__: Allow S3 custom endpoint for direct upload
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 Release date: ``2020-xx-xx``
 
 - `NXPY-148 <https://jira.nuxeo.com/browse/NXPY-148>`__: Use the tmp_path fixture to auto-cleanup created files in tests
+- `NXPY-155 <https://jira.nuxeo.com/browse/NXPY-155>`__: Don't use dots in custom HTTP headers
 - `NXPY-156 <https://jira.nuxeo.com/browse/NXPY-156>`__: Do not silence S3 errors on upload resuming
 - `NXPY-158 <https://jira.nuxeo.com/browse/NXPY-158>`__: Allow S3 custom endpoint for direct upload
 

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -5,6 +5,8 @@ import atexit
 import json
 import logging
 import sys
+from warnings import warn
+
 from urllib3.util.retry import Retry
 
 import requests
@@ -243,9 +245,17 @@ class NuxeoClient(object):
         )
         enrichers = kwargs.pop("enrichers", None)
         if enrichers:
-            headers["X-NXenrichers.document"] = ", ".join(enrichers)
+            headers["enrichers-document"] = ", ".join(enrichers)
 
         headers.update(self.headers)
+
+        if logger.getEffectiveLevel() <= logging.DEBUG:
+            for key in kwargs.get("params") or {}:
+                if '_' in key or '.' in key:
+                    warn(f"Params must not contain _ or . characters: {key}", DeprecationWarning, 2)
+            for key in headers or {}:
+                if '_' in key or '.' in key:
+                    warn(f"Headers must not contain _ or . characters: {key}", DeprecationWarning, 2)
 
         if data and not isinstance(data, bytes) and not raw:
             data = json.dumps(data, default=json_helper)

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -286,16 +286,18 @@ class NuxeoClient(object):
         return resp
 
     def _check_headers_and_params_format(self, headers, params):
-        # type: (Dict[Any, Any], Dict[Any, Any]) -> None
+        # type: (Dict[text, text], Dict[text, text]) -> None
         """Check headers and params keys for dots or underscores and throw a warning if one is found."""
 
         msg = "{!r} {} should not contain '_' nor '.'. Replace with '-' to get rid of that warning."
 
-        for key in headers:
+        for key in headers.keys():
             if "_" in key or "." in key:
                 warn(msg.format(key, "header"), DeprecationWarning, 2)
 
-        for key in params:
+        if not isinstance(params, dict):
+            return
+        for key in params.keys():
             if "_" in key or "." in key:
                 warn(msg.format(key, "param"), DeprecationWarning, 2)
 

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -249,13 +249,7 @@ class NuxeoClient(object):
 
         headers.update(self.headers)
 
-        if logger.getEffectiveLevel() <= logging.DEBUG:
-            for key in kwargs.get("params") or {}:
-                if '_' in key or '.' in key:
-                    warn(f"Params must not contain _ or . characters: {key}", DeprecationWarning, 2)
-            for key in headers or {}:
-                if '_' in key or '.' in key:
-                    warn(f"Headers must not contain _ or . characters: {key}", DeprecationWarning, 2)
+        self._check_headers_and_params_format(headers, kwargs)
 
         if data and not isinstance(data, bytes) and not raw:
             data = json.dumps(data, default=json_helper)
@@ -291,6 +285,17 @@ class NuxeoClient(object):
             del exc
 
         return resp
+
+    def _check_headers_and_params_format(self, headers, kwargs):
+        """Check headers and params keys for dots or underscores and throw a warning if one is found"""
+
+        if logger.getEffectiveLevel() <= logging.DEBUG:
+            for key in kwargs.get("params") or {}:
+                if '_' in key or '.' in key:
+                    warn(f"Params must not contain _ or . characters: {key}", DeprecationWarning, 2)
+            for key in headers or {}:
+                if '_' in key or '.' in key:
+                    warn(f"Headers must not contain _ or . characters: {key}", DeprecationWarning, 2)
 
     def request_auth_token(
         self,

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -248,8 +248,7 @@ class NuxeoClient(object):
             headers["enrichers-document"] = ", ".join(enrichers)
 
         headers.update(self.headers)
-
-        self._check_headers_and_params_format(headers, kwargs)
+        self._check_headers_and_params_format(headers, kwargs.get("params") or {})
 
         if data and not isinstance(data, bytes) and not raw:
             data = json.dumps(data, default=json_helper)
@@ -286,16 +285,19 @@ class NuxeoClient(object):
 
         return resp
 
-    def _check_headers_and_params_format(self, headers, kwargs):
-        """Check headers and params keys for dots or underscores and throw a warning if one is found"""
+    def _check_headers_and_params_format(self, headers, params):
+        # type: (Dict[Any, Any], Dict[Any, Any]) -> None
+        """Check headers and params keys for dots or underscores and throw a warning if one is found."""
 
-        if logger.getEffectiveLevel() <= logging.DEBUG:
-            for key in kwargs.get("params") or {}:
-                if '_' in key or '.' in key:
-                    warn(f"Params must not contain _ or . characters: {key}", DeprecationWarning, 2)
-            for key in headers or {}:
-                if '_' in key or '.' in key:
-                    warn(f"Headers must not contain _ or . characters: {key}", DeprecationWarning, 2)
+        msg = "{!r} {} should not contain '_' nor '.'. Replace with '-' to get rid of that warning."
+
+        for key in headers:
+            if "_" in key or "." in key:
+                warn(msg.format(key, "header"), DeprecationWarning, 2)
+
+        for key in params:
+            if "_" in key or "." in key:
+                warn(msg.format(key, "param"), DeprecationWarning, 2)
 
     def request_auth_token(
         self,

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -286,7 +286,7 @@ class NuxeoClient(object):
         return resp
 
     def _check_headers_and_params_format(self, headers, params):
-        # type: (Dict[text, text], Dict[text, text]) -> None
+        # type: (Dict[text, Any], Dict[text, Any]) -> None
         """Check headers and params keys for dots or underscores and throw a warning if one is found."""
 
         msg = "{!r} {} should not contain '_' nor '.'. Replace with '-' to get rid of that warning."

--- a/nuxeo/comments.py
+++ b/nuxeo/comments.py
@@ -32,9 +32,9 @@ class API(APIEndpoint):
         :param uid: the ID of the comment
         :return: the comment
         """
-        # Adding "&fetch.comment=repliesSummary" to the URL to retrieve replies number as well
+        # Adding "&fetch-comment=repliesSummary" to the URL to retrieve replies number as well
         return super(API, self).get(
-            path=uid, params={"fetch.comment": "repliesSummary"}
+            path=uid, params={"fetch-comment": "repliesSummary"}
         )
 
     def post(self, comment):
@@ -78,8 +78,8 @@ class API(APIEndpoint):
         :param uid: the ID of the comment
         :return: the list of replies
         """
-        # Adding "&fetch.comment=repliesSummary" to the URL to retrieve replies number as well
-        kwargs = {"fetch.comment": "repliesSummary"}
+        # Adding "&fetch-comment=repliesSummary" to the URL to retrieve replies number as well
+        kwargs = {"fetch-comment": "repliesSummary"}
         if isinstance(params, dict):
             kwargs.update(params)
 

--- a/nuxeo/documents.py
+++ b/nuxeo/documents.py
@@ -139,8 +139,8 @@ class API(APIEndpoint):
         """
         path = "id/{}/@comment".format(uid)
 
-        # Adding "&fetch.comment=repliesSummary" to the URL to retrieve replies number as well
-        kwargs = {"fetch.comment": "repliesSummary"}
+        # Adding "&fetch-comment=repliesSummary" to the URL to retrieve replies number as well
+        kwargs = {"fetch-comment": "repliesSummary"}
         if isinstance(params, dict):
             kwargs.update(params)
 

--- a/nuxeo/groups.py
+++ b/nuxeo/groups.py
@@ -19,7 +19,7 @@ class API(APIEndpoint):
 
     def __init__(self, client, endpoint="group", headers=None):
         # type: (NuxeoClient, Text, Optional[Dict[Text, Text]]) -> None
-        self.query = "?fetch.group=memberUsers&fetch.group=memberGroups"
+        self.params = {"fetch-group": ["memberUsers", "memberGroups"]}
         super(API, self).__init__(client, endpoint=endpoint, cls=Group, headers=headers)
 
     def get(self, group_id=None):
@@ -30,8 +30,7 @@ class API(APIEndpoint):
         :param group_id: the id of the group
         :return: the group
         """
-        request_path = "{}{}".format(group_id, self.query)
-        return super(API, self).get(path=request_path)
+        return super(API, self).get(path=group_id, params=self.params)
 
     def post(self, group):
         # type: (Group) -> Group
@@ -41,7 +40,7 @@ class API(APIEndpoint):
         :param group: the group to create
         :return: the created group
         """
-        return super(API, self).post(resource=group, path=self.query)
+        return super(API, self).post(resource=group, params=self.params)
 
     create = post  # Alias for clarity
 

--- a/tests/test_nuxeo.py
+++ b/tests/test_nuxeo.py
@@ -7,7 +7,6 @@ import os
 
 import pytest
 import requests
-from _pytest.recwarn import warns
 from requests.exceptions import ConnectionError, ReadTimeout
 
 from nuxeo import constants
@@ -376,30 +375,28 @@ def test_unauthorized(server):
 
 def test_param_format(server, recwarn):
     params = "stringnotadict"
-    headers = {"test-wrong-typo": "error"}
     with pytest.raises(HTTPError):
-        server.client.request("GET", "test", headers=headers, params=params)
+        server.client.request("GET", "test", params=params)
 
     assert len(recwarn) == 0
 
     params = {"test.wrong.typo": "error"}
-    with warns(
+    with pytest.warns(
         DeprecationWarning,
         match=r"'test.wrong.typo' param should not contain '_' nor '.'. Replace with '-' "
         r"to get rid of that warning.",
     ):
         with pytest.raises(HTTPError):
-            server.client.request("GET", "test", headers=headers, params=params)
+            server.client.request("GET", "test", params=params)
 
 
 def test_header_format(server):
-    params = None
     headers = {"test.wrong.typo": "error"}
 
-    with warns(
+    with pytest.warns(
         DeprecationWarning,
         match=r"'test.wrong.typo' header should not contain '_' nor '.'. Replace with '-' "
         r"to get rid of that warning.",
     ):
         with pytest.raises(HTTPError):
-            server.client.request("GET", "test", headers=headers, params=params)
+            server.client.request("GET", "test", headers=headers)


### PR DESCRIPTION
We don't want to use dots nor underscores in headers
sent to Nuxeo as NGINX doesn't allow their usage
for HTTP.
Underscores and dots have been replaced with hyphen to
not have the issue with NGINX users.
A warning is now thrown in case a dot or an underscore
is encountered in a header or a request params.
Tests will now fail if a warning is encountered.
Also changelog has been updated.