### PR TITLE
NXPY-145: Detect and log appropriate debug info when the transfer if …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 Release date: ``2020-xx-xx``
 
 - `NXPY-159 <https://jira.nuxeo.com/browse/NXPY-159>`__: Allow to pass additional arguments to ``Batch.complete()``
+- `NXPY-145 <https://jira.nuxeo.com/browse/NXPY-145>`__: Detect and log appropriate debug info when the transfer if chunked
 
 Technical changes
 -----------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,6 @@ addopts =
     --cov=nuxeo
     --showlocals
     --failed-first
-    --no-print-logs
     --log-level=DEBUG
     # -W error
     -v

--- a/tests/test_log_response.py
+++ b/tests/test_log_response.py
@@ -72,6 +72,19 @@ class ResponseMxf(Response):
         raise OverflowError("join() result is too long")
 
 
+class ResponseChunkedContents(Response):
+    def __init__(self):
+        super().__init__()
+        self.headers["content-type"] = "text/plain"
+        self.headers["content-length"] = "1024"
+        self.headers["transfer-encoding"] = "chunked"
+        self.url = "http://localhost:8080/nuxeo/small%20file.txt"
+
+    @property
+    def content(self):
+        return "TADA!".encode("utf-8")
+
+
 class ResponseTextOk(Response):
     def __init__(self):
         super().__init__()
@@ -116,6 +129,7 @@ class ResponseTextTooLong(Response):
         (ResponseTextOk, "TADA!"),
         (ResponseTextTooLong, "too much text"),
         (ResponseTextError, "no enough memory"),
+        (ResponseChunkedContents, "chunked contents"),
     ],
 )
 def test_response(caplog, response, pattern):


### PR DESCRIPTION
…chunked

Also fixed a pytest warning:
```
PytestDeprecationWarning: --no-print-logs is deprecated and scheduled for removal in pytest 6.0.
```