### PR TITLE
NXPY-163: Still allow outdated servers to use the S3 batch handler

### DIFF
--- a/nuxeo/auth.py
+++ b/nuxeo/auth.py
@@ -9,8 +9,8 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Text  # noqa
-        from requests import Request  # noqa
+        from typing import Text
+        from requests import Request
 except ImportError:
     pass
 

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -46,8 +46,8 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Any, Dict, Optional, Text, Tuple, Type, Union  # noqa
-        from requests.auth import AuthBase  # noqa
+        from typing import Any, Dict, Optional, Text, Tuple, Type, Union
+        from requests.auth import AuthBase
 
         AuthType = Optional[Union[Tuple[Text, Text], AuthBase]]
 except ImportError:

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -419,7 +419,11 @@ class NuxeoClient(object):
             # This endpoint returns too many information and pollute logs.
             # Besides contents of this call are stored into the .server_info attr.
             content = "<CMIS details saved into the *server_info* attr>"
-        elif not content_type.startswith("text") and "json" not in content_type and content_size:
+        elif (
+            not content_type.startswith("text")
+            and "json" not in content_type
+            and content_size
+        ):
             # The Content-Type is a binary one, but it does not contain JSON data
             # Skipped binary types are everything but "text/xxx":
             #   https://www.iana.org/assignments/media-types/media-types.xhtml
@@ -434,7 +438,9 @@ class NuxeoClient(object):
                 content_size = len(content)
                 if content_size > limit_size:
                     content = content[:limit_size]
-                    content = "{} [...] ({:,} bytes skipped)".format(content, content_size - limit_size)
+                    content = "{} [...] ({:,} bytes skipped)".format(
+                        content, content_size - limit_size
+                    )
             except (MemoryError, OverflowError):
                 # OverflowError: join() result is too long (in requests.models.content)
                 # Still check for memory errors, this should never happen; or else,

--- a/nuxeo/comments.py
+++ b/nuxeo/comments.py
@@ -9,8 +9,8 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Any, Dict, List, Optional, Text  # noqa
-        from .client import NuxeoClient  # noqa
+        from typing import Any, Dict, List, Optional, Text
+        from .client import NuxeoClient
 except ImportError:
     pass
 

--- a/nuxeo/compat.py
+++ b/nuxeo/compat.py
@@ -5,16 +5,16 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Text, Type, Union  # noqa
-        from requests import HTTPError  # noqa
+        from typing import Text, Type, Union
+        from requests import HTTPError
 except ImportError:
     pass
 
 try:
     from urllib.parse import quote, urlencode
 except ImportError:
-    from urllib2 import quote  # noqa
-    from urllib import urlencode  # noqa
+    from urllib2 import quote
+    from urllib import urlencode
 
 try:
     long = long
@@ -51,3 +51,14 @@ def get_text(data):
     if not isinstance(data, text):
         data = data.decode("utf-8")
     return data
+
+
+__all__ = (
+    "HTTPError",
+    "get_bytes",
+    "get_text",
+    "long",
+    "quote",
+    "text",
+    "urlencode",
+)

--- a/nuxeo/directories.py
+++ b/nuxeo/directories.py
@@ -9,8 +9,8 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Any, Dict, Text, Optional, Union  # noqa
-        from .client import NuxeoClient  # noqa
+        from typing import Any, Dict, Text, Optional, Union
+        from .client import NuxeoClient
 except ImportError:
     pass
 

--- a/nuxeo/documents.py
+++ b/nuxeo/documents.py
@@ -12,10 +12,10 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Any, Dict, List, Optional, Text, Union  # noqa
-        from .client import NuxeoClient  # noqa
-        from .models import Blob, Comment, Workflow  # noqa
-        from .operations import API as OperationsAPI  # noqa
+        from typing import Any, Dict, List, Optional, Text, Union
+        from .client import NuxeoClient
+        from .models import Blob, Workflow
+        from .operations import API as OperationsAPI
 except ImportError:
     pass
 

--- a/nuxeo/endpoint.py
+++ b/nuxeo/endpoint.py
@@ -9,9 +9,9 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Any, Dict, Optional, Text, Type, Union  # noqa
-        from .client import NuxeoClient  # noqa
-        from .models import Model  # noqa
+        from typing import Any, Dict, Optional, Text, Type
+        from .client import NuxeoClient
+        from .models import Model
 except ImportError:
     pass
 

--- a/nuxeo/exceptions.py
+++ b/nuxeo/exceptions.py
@@ -9,7 +9,7 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Any, Dict, List, Optional, Text  # noqa
+        from typing import Any, Dict, List, Optional, Text
 except ImportError:
     pass
 

--- a/nuxeo/groups.py
+++ b/nuxeo/groups.py
@@ -8,8 +8,8 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Dict, Optional, Text  # noqa
-        from .client import NuxeoClient  # noqa
+        from typing import Dict, Optional, Text
+        from .client import NuxeoClient
 except ImportError:
     pass
 

--- a/nuxeo/handlers/default.py
+++ b/nuxeo/handlers/default.py
@@ -11,10 +11,11 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Any, Callable, Generator, Set, Text, Tuple, Union  # noqa
-        from .models import Batch, Blob, BufferBlob, FileBlob  # noqa
+        from typing import Any, Callable, Generator, Text, Tuple, Union
+        from ..models import Batch, Blob, BufferBlob, FileBlob
+        from ..uploads import API
 
-        ActualBlob = Union[BufferBlob, FileBlob]  # noqa
+        ActualBlob = Union[BufferBlob, FileBlob]
 except ImportError:
     pass
 

--- a/nuxeo/handlers/s3.py
+++ b/nuxeo/handlers/s3.py
@@ -22,7 +22,7 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Any, Dict, Generator, List, Set, Tuple  # noqa
+        from typing import Any, Dict, Generator, List, Tuple
 except ImportError:
     pass
 

--- a/nuxeo/models.py
+++ b/nuxeo/models.py
@@ -13,18 +13,17 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Any, BinaryIO, Dict, List, Optional, Text, Union  # noqa
-        from io import FileIO  # noqa
-        from .comments import API as CommentsAPI  # noqa
-        from .directories import API as DirectoriesAPI  # noqa
-        from .documents import API as DocumentsAPI  # noqa
-        from .endpoint import APIEndpoint  # noqa
-        from .groups import API as GroupsAPI  # noqa
-        from .operations import API as OperationsAPI  # noqa
-        from .tasks import API as TasksAPI  # noqa
-        from .uploads import API as UploadsAPI  # noqa
-        from .users import API as UsersAPI  # noqa
-        from .workflows import API as WorkflowsAPI  # noqa
+        from typing import Any, BinaryIO, Dict, List, Optional, Text, Union
+        from .comments import API as CommentsAPI
+        from .directories import API as DirectoriesAPI
+        from .documents import API as DocumentsAPI
+        from .endpoint import APIEndpoint
+        from .groups import API as GroupsAPI
+        from .operations import API as OperationsAPI
+        from .tasks import API as TasksAPI
+        from .uploads import API as UploadsAPI
+        from .users import API as UsersAPI
+        from .workflows import API as WorkflowsAPI
 except ImportError:
     pass
 

--- a/nuxeo/operations.py
+++ b/nuxeo/operations.py
@@ -18,9 +18,9 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from requests import Response  # noqa
-        from typing import Any, Dict, Optional, Text, Tuple, Type  # noqa
-        from .client import NuxeoClient  # noqa
+        from requests import Response
+        from typing import Any, Dict, Optional, Text, Tuple, Type
+        from .client import NuxeoClient
 except ImportError:
     pass
 

--- a/nuxeo/tasks.py
+++ b/nuxeo/tasks.py
@@ -10,9 +10,8 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Any, Dict, List, Optional, Text, Union  # noqa
-        from .client import NuxeoClient  # noqa
-        from .models import Workflow  # noqa
+        from typing import Any, Dict, List, Optional, Text, Union
+        from .client import NuxeoClient
 except ImportError:
     pass
 

--- a/nuxeo/uploads.py
+++ b/nuxeo/uploads.py
@@ -22,11 +22,12 @@ try:
             Text,
             Tuple,
             Union,
-        )  # noqa
-        from .client import NuxeoClient  # noqa
-        from .models import BufferBlob, FileBlob  # noqa
+        )
+        from .client import NuxeoClient
+        from .models import BufferBlob, FileBlob
+        from .handlers.default import Uploader
 
-        ActualBlob = Union[BufferBlob, FileBlob]  # noqa
+        ActualBlob = Union[BufferBlob, FileBlob]
 except ImportError:
     pass
 

--- a/nuxeo/users.py
+++ b/nuxeo/users.py
@@ -8,8 +8,8 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Dict, Optional, Text  # noqa
-        from .client import NuxeoClient  # noqa
+        from typing import Dict, Optional, Text
+        from .client import NuxeoClient
 except ImportError:
     pass
 

--- a/nuxeo/utils.py
+++ b/nuxeo/utils.py
@@ -12,8 +12,8 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from _hashlib import HASH  # noqa
-        from typing import Any, Dict, List, Optional, Text, Tuple, Type, Union  # noqa
+        from _hashlib import HASH
+        from typing import Any, Dict, List, Optional, Text, Tuple
 except ImportError:
     pass
 

--- a/nuxeo/workflows.py
+++ b/nuxeo/workflows.py
@@ -9,10 +9,10 @@ try:
     from typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
-        from typing import Any, Dict, List, Optional, Text, Union  # noqa
-        from .client import NuxeoClient  # noqa
-        from .models import Document, Task  # noqa
-        from .tasks import API as TasksAPI  # noqa
+        from typing import Any, Dict, List, Optional, Text
+        from .client import NuxeoClient
+        from .models import Document, Task
+        from .tasks import API as TasksAPI
 except ImportError:
     pass
 


### PR DESCRIPTION
Allow outdated servers (without the `refreshToken` API) to still work with S3.
It will just end on a ExpiredToken error, but it is better than a 404 error.