### PR TITLE
NXPY-166: Move to GitHub Actions for testing

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: Code quality
+
+on:
+  pull_request:
+    paths:
+    - '**/*.py'
+
+jobs:
+  job:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: python -m pip install -U pip tox
+
+    - name: Code quality check
+      run: tox -e lint

--- a/.github/workflows/types.yml
+++ b/.github/workflows/types.yml
@@ -1,0 +1,24 @@
+name: Type annotations
+
+on:
+  pull_request:
+    paths:
+    - '**/*.py'
+
+jobs:
+  job:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install dependencies
+      run: python -m pip install -U pip tox
+
+    - name: Type annotations check
+      run: tox -e types

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,40 @@
+name: Unit tests
+
+on: [pull_request]
+
+env:
+  SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    services:
+      nuxeo:
+        image: nuxeo/nuxeo:master
+        ports:
+          - 8080:8080
+
+    strategy:
+      matrix:
+        python:
+          # - 2.7 (NXPY-167)
+          # - 3.5 (NXPY-99)
+          - 3.6
+          - 3.7
+          - 3.8
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+
+    - name: Install dependencies
+      run: python -m pip install -U pip tox
+
+    - name: Unit tests
+      # Run tox using the version of Python in `PATH`
+      run: tox -e py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Release date: ``2020-xx-xx``
 - `NXPY-145 <https://jira.nuxeo.com/browse/NXPY-145>`__: Detect and log appropriate debug info when the transfer if chunked
 - `NXPY-163 <https://jira.nuxeo.com/browse/NXPY-163>`__: Add the capability to refresh tokens in third-party batch handlers
 - `NXPY-164 <https://jira.nuxeo.com/browse/NXPY-164>`__: Clean-up code smells found by Sourcery
+- `NXPY-166 <https://jira.nuxeo.com/browse/NXPY-166>`__: Move to GitHub Actions for testing
 
 Technical changes
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ Client Library for Nuxeo API
 |Build Status| |Coverage| |Lines of code|
 
 The Nuxeo Python Client is a Python client library for the Nuxeo
-Automation and REST API. It works with both Python 2 and 3.
+Automation and REST API. It works with both Python 2.7 and 3.5+.
 
 This is an ongoing project, supported by Nuxeo.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -168,7 +168,6 @@ def test_fetch_acls(server):
 
 def test_fetch_audit(server):
     with Doc(server) as doc:
-        # XXX: Replace with NuxeoDrive.WaitForElasticsearchCompletion
         time.sleep(1)
 
         audit = doc.fetch_audit()

--- a/tox.ini
+++ b/tox.ini
@@ -2,25 +2,28 @@
 envlist =
     lint
     types
+    # py2.7
     py3{5,6,7,8}
 skip_missing_interpreters = True
 
 [testenv]
-passenv = NXDRIVE_TEST_NUXEO_URL SENTRY_* SKIP_SENTRY
+passenv =
+    NXDRIVE_TEST_NUXEO_URL
+    SENTRY_DSN
+    SENTRY_ENV
+    SKIP_SENTRY
 deps =
     -e .[s3]
     moto
     pytest
     pytest-cov
     sentry-sdk
-commands =
-    python -m pytest {posargs}
+commands = python -m pytest {posargs}
 
 [testenv:lint]
 description = Code quality check
 basepython = python3
-deps =
-    flake8
+deps = flake8
 commands =
     python -m flake8 examples nuxeo tests
 
@@ -28,7 +31,5 @@ commands =
 description = Type annotations check
 basepython = python3
 ignore_outcome = true
-deps =
-    mypy
-commands =
-    python -m mypy --ignore-missing-imports nuxeo tests
+deps = mypy
+commands = python -m mypy --ignore-missing-imports nuxeo tests


### PR DESCRIPTION
Dropped the support for Python 3.4 at the same time.