### PR TITLE
NXPY-171: Set higher default timeouts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,8 @@ Technical changes
 - Added ``docuid`` argument to nuxeo/comments.py::\ ``API.post()``
 - Changed ``comment (Comment)`` argument of nuxeo/comments.py::\ ``API.post()`` to ``text (str)``
 - Added nuxeo/compat.py::\ ``lru_cache()``
+- Changed nuxeo/constants.py::\ ``TIMEOUT_CONNECT`` from ``5`` to ``10``
+- Changed nuxeo/constants.py::\ ``TIMEOUT_READ`` from ``30`` to ``600``
 - Added nuxeo/uploads.py::\ ``API.refresh_token()``
 - Added nuxeo/utils.py::\ ``cmp()``
 - Added nuxeo/utils.py::\ ``get_response_content()``

--- a/nuxeo/constants.py
+++ b/nuxeo/constants.py
@@ -38,8 +38,8 @@ RETRY_METHODS = frozenset(["GET", "POST", "PUT", "DELETE"])
 RETRY_STATUS_CODES = [429, 500, 503, 504]
 
 # Connection and read timeout, in seconds
-TIMEOUT_CONNECT = 5
-TIMEOUT_READ = 30
+TIMEOUT_CONNECT = 10
+TIMEOUT_READ = 60 * 10
 
 # Size of chunks for the upload
 UPLOAD_CHUNK_SIZE = 20 * 1024 * 1024  # 20 MiB


### PR DESCRIPTION
- `TIMEOUT_CONNECT`: 5 -> 10
- `TIMEOUT_READ`: 30 -> 600

It happens that the `TIMEOUT_READ` is set at the socket level at the first HTTP(S) connection. And then this value is used for next calls. And even if we set a higher value in specific calls, it will not be taken into account. So we are now using a bigger value to prevent `socket.timeout: The write operation timed out` errors at the SSL level.