### PR TITLE
NXPY-163: Fix AuthorizationHeaderMalformed

### DIFF
--- a/nuxeo/handlers/s3.py
+++ b/nuxeo/handlers/s3.py
@@ -74,8 +74,8 @@ class UploaderS3(Uploader):
         """Method called automatically by boto3 to refresh tokens when needed."""
         data = self.service.refresh_token(self.batch)
         return {
-            "access_key": data["awsSecretAccessKey"],
-            "secret_key": data["awsSecretKeyId"],
+            "access_key": data["awsSecretKeyId"],
+            "secret_key": data["awsSecretAccessKey"],
             "token": data["awsSessionToken"],
             "expiry_time": datetime.fromtimestamp(
                 data["expiration"] / 1000, tz=tzlocal()


### PR DESCRIPTION
It happens that `access_key` and `secret_key` were inverted. Bad names ...