### PR TITLE
NXPY-177: Prevent AttributeError when fetching the server version and…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Release date: ``2020-xx-xx``
 - `NXPY-173 <https://jira.nuxeo.com/browse/NXPY-173>`__: Consign additionnal parameters sent to each HTTP requests in logs
 - `NXPY-174 <https://jira.nuxeo.com/browse/NXPY-174>`__: Improve ``test_repository.py`` reliability
 - `NXPY-176 <https://jira.nuxeo.com/browse/NXPY-176>`__: Add ``Nuxeo.can_use()`` to determine if a given operation is available
+- `NXPY-177 <https://jira.nuxeo.com/browse/NXPY-177>`__: Prevent ``AttributeError`` when fetching the server version and the response is bad (and return "unknown")
 
 Technical changes
 -----------------

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -359,27 +359,24 @@ class NuxeoClient(object):
 
         :param bool force: Force information renewal.
         """
-
         if force or self._server_info is None:
             response = self.request("GET", "json/cmis", default={})
-            if isinstance(response, requests.Response):
-                try:
-                    info = response.json()["default"]
-                except Exception:
-                    logger.warning(
-                        "Invalid response data when called server_info()", exc_info=True
-                    )
-                    info = None
-            else:
-                info = response
-            self._server_info = info
+            try:
+                self._server_info = response.json()["default"]
+            except Exception:
+                logger.error(
+                    "Invalid response data when called server_info()", exc_info=True
+                )
         return self._server_info
 
     @property
     def server_version(self):
         # type: () -> Text
-        """ Return the server version. """
-        return self.server_info().get("productVersion", "")
+        """ Return the server version or "unknown". """
+        try:
+            return self.server_info()["productVersion"]
+        except Exception:
+            return "unknown"
 
     @staticmethod
     def _handle_error(error):

--- a/tests/test_nuxeo.py
+++ b/tests/test_nuxeo.py
@@ -301,10 +301,30 @@ def test_server_version(server):
     assert server.client.server_version
     assert str(server.client)
 
-    # Bad call
+
+def test_server_version_bad_url(server):
     server.client._server_info = None
     with SwapAttr(server.client, "host", "http://example-42.org/"):
-        assert not server.client.server_version
+        assert server.client.server_version == "unknown"
+        assert str(server.client)
+
+    # Another call, it must work as expected
+    assert server.client.server_version != "unknown"
+    assert str(server.client)
+
+
+def test_server_version_bad_response_from_server_info(server):
+    """
+    Test bad response data (not serializable JSON).
+    NXPY-177: the call should not fail on an AttributeError.
+    """
+    server.client._server_info = None
+    with responses.RequestsMock() as rsps:
+        rsps.add(responses.GET, server.client.host + "json/cmis", body="...")
+        assert server.client.server_version == "unknown"
+
+    # Another call, it must work as expected
+    assert server.client.server_version != "unknown"
 
 
 def test_set_repository(server):


### PR DESCRIPTION
… the response is bad

Return "unknown" in that case. Another call to the `server_version` attribute will try to refetch server details and the situation may be fixed then.