### PR TITLE
NXPY-178: Use a uniq ID for the S3 direct upload key

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,11 +21,13 @@ Release date: ``2020-xx-xx``
 - `NXPY-174 <https://jira.nuxeo.com/browse/NXPY-174>`__: Improve ``test_repository.py`` reliability
 - `NXPY-176 <https://jira.nuxeo.com/browse/NXPY-176>`__: Add ``Nuxeo.can_use()`` to determine if a given operation is available
 - `NXPY-177 <https://jira.nuxeo.com/browse/NXPY-177>`__: Prevent ``AttributeError`` when fetching the server version and the response is bad (and return "unknown")
+- `NXPY-178 <https://jira.nuxeo.com/browse/NXPY-178>`__: Use a uniq ID for the S3 direct upload key
 
 Technical changes
 -----------------
 
 - ``Batch.complete()`` now handles additional parameters
+- Added ``Batch.key``
 - Added ``Nuxeo.can_use()``
 - Added ``Uploader.timeout()``
 - Added nuxeo/constants.py::\ ``LOG_LIMIT_SIZE``

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -360,8 +360,8 @@ class NuxeoClient(object):
         :param bool force: Force information renewal.
         """
         if force or self._server_info is None:
-            response = self.request("GET", "json/cmis", default={})
             try:
+                response = self.request("GET", "json/cmis")
                 self._server_info = response.json()["default"]
             except Exception:
                 logger.error(

--- a/nuxeo/handlers/s3.py
+++ b/nuxeo/handlers/s3.py
@@ -42,7 +42,9 @@ class UploaderS3(Uploader):
         # Instantiate the S3 client
         s3_info = self.batch.extraInfo
         self.bucket = s3_info["bucket"]
-        self.key = "{}/{}".format(s3_info["baseKey"].rstrip("/"), self.blob.name)
+        self.key = "{}/{}".format(
+            s3_info["baseKey"].rstrip("/"), self.batch.key or self.blob.name
+        )
 
         if not s3_client:
             # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html#multithreading-multiprocessing

--- a/nuxeo/models.py
+++ b/nuxeo/models.py
@@ -125,6 +125,7 @@ class Batch(Model):
         "dropped": None,
         "extraInfo": None,
         "etag": None,
+        "key": "",
         "multiPartUploadId": None,
         "provider": None,
         "upload_idx": 0,

--- a/tests/test_upload_s3.py
+++ b/tests/test_upload_s3.py
@@ -70,6 +70,23 @@ def batch(aws_pwd, bucket, server):
     return obj
 
 
+def test_upload_blob_with_bad_characters(tmp_path, batch, bucket, server, s3):
+    file_in = tmp_path / "file_in (1).bin"
+    file_in.write_bytes(os.urandom(1024 * 1024 * 5))
+
+    blob = FileBlob(str(file_in))
+
+    # Simulate a single upload that failed
+    uploader = UploaderS3(server.uploads, batch, blob, 1024 * 1024 * 10, s3_client=s3)
+
+    # Create a bucket
+    uploader.s3_client.create_bucket(Bucket=bucket)
+
+    # Upload he file, it must work
+    uploader.upload()
+    assert uploader.batch.etag is not None
+
+
 def test_upload_not_chunked(tmp_path, batch, bucket, server, s3):
     file_in = tmp_path / "file_in"
     file_in.write_bytes(os.urandom(1024 * 1024 * 5))


### PR DESCRIPTION
Before the patch, the key was computed using the blob name.
And it would fail if the name contains disallowed characters like parenthesis:

    HTTPError(400), error: 'java.lang.IllegalArgumentException: Invalid key: file (1).bin'

So the new code now uses a UUID.