### PR TITLE
NXPY-185: Add the Blob.batchId attribute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,10 +7,12 @@ Changelog
 Release date: ``2020-xx-xx``
 
 - `NXPY-183 <https://jira.nuxeo.com/browse/NXPY-183>`__: Set the TCP keep alive option by default
+- `NXPY-185 <https://jira.nuxeo.com/browse/NXPY-185>`__: Add the ``Blob.batchId`` attribute
 
 Technical changes
 -----------------
 
+- Added ``Blob.batchId`` and deprecated ``Blob.batch_id``
 - Added ``constants.LINUX``
 - Added ``constants.MAC``
 - Added ``constants.TCP_KEEPALIVE``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 Release date: ``2020-xx-xx``
 
-- `NXPY-182 <https://jira.nuxeo.com/browse/NXPY-182>`__: Set the TCP keep alive option by default
+- `NXPY-183 <https://jira.nuxeo.com/browse/NXPY-183>`__: Set the TCP keep alive option by default
 
 Technical changes
 -----------------

--- a/nuxeo/handlers/default.py
+++ b/nuxeo/handlers/default.py
@@ -126,7 +126,7 @@ class Uploader(object):
         """ Add the uploaded blob info to the batch. """
         if self.is_complete():
             # All the parts have been uploaded, update the attributes
-            self.blob.batch_id = self.batch.uid
+            self.blob.batchId = self.batch.uid
             self.batch.blobs[self.batch.upload_idx] = self.blob
             self.batch.upload_idx += 1
 

--- a/nuxeo/handlers/default.py
+++ b/nuxeo/handlers/default.py
@@ -169,7 +169,7 @@ class ChunkUploader(Uploader):
             return
 
         to_upload = set(range(self.chunk_count)) - set(self.blob.uploadedChunkIds)
-        self._to_upload = sorted(list(to_upload))
+        self._to_upload = sorted(to_upload)
 
     def is_complete(self):
         # type: () -> bool

--- a/nuxeo/models.py
+++ b/nuxeo/models.py
@@ -235,6 +235,7 @@ class Blob(Model):
     """ Blob superclass used for metadata. """
 
     _valid_properties = {
+        "batchId": "",
         "chunkCount": 0,
         "fileIdx": None,
         "mimetype": None,
@@ -258,10 +259,34 @@ class Blob(Model):
             model.uploadedSize = model.size
         return model
 
+    @property
+    def batch_id(self):
+        """Kept for compatibility reasons, will be removed in version 4.0."""
+        from warnings import warn
+
+        warn(
+            "batch_id is deprecated and will be removed in version 4.0. Use batchId instead.",
+            DeprecationWarning,
+            2,
+        )
+        return self.batchId
+
+    @batch_id.setter
+    def batch_id(self, value):
+        """Kept for compatibility reasons, will be removed in version 4.0."""
+        from warnings import warn
+
+        warn(
+            "batch_id is deprecated and will be removed in version 4.0. Use batchId instead.",
+            DeprecationWarning,
+            2,
+        )
+        self.batchId = value
+
     def to_json(self):
         # type: () -> Dict[Text, Text]
         """ Return a JSON object used during the upload. """
-        return {"upload-batch": self.batch_id, "upload-fileId": text(self.fileIdx)}
+        return {"upload-batch": self.batchId, "upload-fileId": text(self.fileIdx)}
 
 
 class BufferBlob(Blob):

--- a/nuxeo/operations.py
+++ b/nuxeo/operations.py
@@ -178,7 +178,7 @@ class API(APIEndpoint):
         url = "site/automation/{}".format(command)
         if isinstance(input_obj, Blob):
             url = "{}/upload/{}/{}/execute/{}".format(
-                self.client.api_path, input_obj.batch_id, input_obj.fileIdx, command
+                self.client.api_path, input_obj.batchId, input_obj.fileIdx, command
             )
             input_obj = None
 

--- a/nuxeo/uploads.py
+++ b/nuxeo/uploads.py
@@ -63,7 +63,7 @@ class API(APIEndpoint):
         resource = super(API, self).get(path=path)
 
         if file_idx is not None:
-            resource.batch_id = batch_id
+            resource.batchId = batch_id
             resource.fileIdx = file_idx
         elif not resource:
             return []

--- a/nuxeo/uploads.py
+++ b/nuxeo/uploads.py
@@ -128,7 +128,7 @@ class API(APIEndpoint):
             endpoint = "{}/handlers".format(self.endpoint)
             try:
                 response = self.client.request("GET", endpoint)
-                self.__handlers = [h for h in response.json()["handlers"][0].values()]
+                self.__handlers = list(response.json()["handlers"][0].values())
             except Exception:
                 # This is not good, no handlers == no uploads!
                 # Return an empty list without modifying .__handlers


### PR DESCRIPTION
The `Blob.batch_id` attribute is now deprecated and will be removed in version 4.0.