### PR TITLE
NXPY-188: Set the Content-Type for uploads done via S3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 Release date: ``2020-xx-xx``
 
-- `NXPY-1 <https://jira.nuxeo.com/browse/NXPY-1>`__:
+- `NXPY-188 <https://jira.nuxeo.com/browse/NXPY-188>`__: Set the ``Content-Type`` for uploads done via S3
 
 Technical changes
 -----------------


### PR DESCRIPTION
This will fix document preview on Web-UI when updating a blob with the S3 upload provider.

Also fix a flake8 error:

    C414 Unnecessary list call within sorted().