### PR TITLE
NXPY-192: Add support for Python 3.10

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,15 +16,13 @@ jobs:
     strategy:
       matrix:
         nuxeo:
-          - master
           - '10.10'
-          - '9.10'
         python:
-          - 2.7
-          # - 3.5 (NXPY-99)
-          - 3.6
-          - 3.7
-          - 3.8
+          # Minimum supported version
+          - '2.7'
+          # Maximum supported version
+          # Note: 3.10 is still in alpha, so we stick with 3.9 until there is an official 3.10
+          - '3.9'
 
     services:
       nuxeo:
@@ -55,4 +53,4 @@ jobs:
       env:
         SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
       # Run tox using the version of Python in `PATH`
-      run: tox -e py
+      run: python -m tox -e py

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 Release date: ``2020-xx-xx``
 
-- `NXPY- <https://jira.nuxeo.com/browse/NXPY->`__:
+- `NXPY-192 <https://jira.nuxeo.com/browse/NXPY-192>`__: Add support for Python 3.10
 
 Technical changes
 -----------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Libraries
 
 [options]

--- a/tests/test_batchupload.py
+++ b/tests/test_batchupload.py
@@ -209,13 +209,13 @@ def test_handlers_custom(server):
 
 
 @pytest.mark.parametrize(
-    "filename, mimetypes, expected_mimetype",
+    "filename, mimetypes",
     [
-        ("file.bmp", ["image/bmp", "image/x-ms-bmp"], "image/bmp"),
-        ("file.pdf", ["application/pdf"], "application/pdf"),
+        ("file.bmp", ["image/bmp", "image/x-ms-bmp"]),
+        ("file.pdf", ["application/pdf"]),
     ],
 )
-def test_mimetype(filename, mimetypes, expected_mimetype, tmp_path, server):
+def test_mimetype(filename, mimetypes, tmp_path, server):
     file_in = tmp_path / filename
     file_in.write_bytes(b"0" * 42)
     blob = FileBlob(str(file_in))
@@ -241,7 +241,7 @@ def test_mimetype(filename, mimetypes, expected_mimetype, tmp_path, server):
 
         # Check the mimetype set by the server is correct
         mimetype = info["properties"]["file:content"]["mime-type"]
-        assert mimetype == expected_mimetype
+        assert mimetype in mimetypes
     finally:
         doc.delete()
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     lint
     types
     py27
-    py3{5,6,7,8}
+    py3{5,6,7,8,9,10}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Also test only only Nuxeo 10.10 and lower + upper Python supported versions.