### PR TITLE
NXPY-199: Add support for idempotent calls

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,14 @@ Changelog
 
 Release date: ``2020-xx-xx``
 
-- `NXPY-1 <https://jira.nuxeo.com/browse/NXPY-1>`__:
+- `NXPY-199 <https://jira.nuxeo.com/browse/NXPY-199>`__: Add support for idempotent calls
+
+Technical changes
+-----------------
+
+- Added nuxeo/constants.py::\ ``IDEMPOTENCY_KEY``
+- Added nuxeo/exceptions.py::\ ``Conflict``
+- Added nuxeo/exceptions.py::\ ``OngoingRequestError``
 
 4.0.0
 -----

--- a/nuxeo/client.py
+++ b/nuxeo/client.py
@@ -400,18 +400,19 @@ class NuxeoClient(object):
 
         :param error: The error to handle
         """
-        if isinstance(error, requests.HTTPError):
-            try:
-                error_data = error.response.json()
-            except ValueError:
-                error_data = {
-                    "status": error.response.status_code,
-                    "message": error.response.content,
-                }
+        if not isinstance(error, requests.HTTPError):
+            return error
 
-            error_cls = HTTP_ERROR.get(error_data.get("status"), HTTPError)
-            error = error_cls.parse(error_data)
-        return error
+        try:
+            error_data = error.response.json()
+        except ValueError:
+            error_data = {
+                "status": error.response.status_code,
+                "message": error.response.content,
+            }
+
+        error_cls = HTTP_ERROR.get(error_data.get("status"), HTTPError)
+        return error_cls.parse(error_data)
 
     @staticmethod
     def _log_response(response, limit_size=LOG_LIMIT_SIZE):

--- a/nuxeo/constants.py
+++ b/nuxeo/constants.py
@@ -23,6 +23,9 @@ DEFAULT_URL = "http://localhost:8080/nuxeo/"
 #   - 'applicationName' URL parameter
 DEFAULT_APP_NAME = "Python client"
 
+# Name of the HTTP header for idempotent requests
+IDEMPOTENCY_KEY = "Idempotency-Key"
+
 # Maximum size to not overflow when logging raw content of a HTTP response
 LOG_LIMIT_SIZE = 5 * 1024 * 1024  # 5 MiB
 

--- a/nuxeo/exceptions.py
+++ b/nuxeo/exceptions.py
@@ -89,6 +89,12 @@ class HTTPError(RetryError, NuxeoError):
         return model
 
 
+class Conflict(HTTPError):
+    """ Exception thrown when the HTTPError code is 409. """
+
+    status = 409
+
+
 class Forbidden(HTTPError):
     """ Exception thrown when the HTTPError code is 403. """
 
@@ -111,6 +117,23 @@ class InvalidUploadHandler(NuxeoError):
         # type: () -> Text
         msg = "{}: the upload handler {!r} is not one of {}."
         return msg.format(type(self).__name__, self.handler, self.handlers)
+
+    def __str__(self):
+        # type: () -> Text
+        return repr(self)
+
+
+class OngoingRequestError(Conflict):
+    """ Exception thrown when doing an idempotent call that is already being processed. """
+
+    def __init__(self, request_uid):
+        # type: (Text) -> None
+        self.request_uid = request_uid
+
+    def __repr__(self):
+        # type: () -> Text
+        msg = "{}: a request with the idempotency key {!r} is already being processed."
+        return msg.format(type(self).__name__, self.request_uid)
 
     def __str__(self):
         # type: () -> Text

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,8 +1,19 @@
-from nuxeo.exceptions import Forbidden, HTTPError, Unauthorized
+from nuxeo.exceptions import (
+    Conflict,
+    Forbidden,
+    HTTPError,
+    OngoingRequestError,
+    Unauthorized,
+)
 
 
 # We do not need to set-up a server and log the current test
 skip_logging = True
+
+
+def test_crafted_conflict():
+    exc = Conflict()
+    assert exc.status == 409
 
 
 def test_crafted_forbidden():
@@ -37,6 +48,12 @@ def test_crafted_httperror_parse():
     assert exc.status == -1
     assert exc.message == "oups"
     assert exc.stacktrace == "NulPointerException: bla*3"
+
+
+def test_crafted_ongoing_request_error():
+    exc = OngoingRequestError("123-456-789")
+    assert exc.status == 409
+    assert exc.request_uid == "123-456-789"
 
 
 def test_crafted_unauthorized():


### PR DESCRIPTION
Introduced:

- `OngoingRequestError` and `Conflict` exceptions.
- `IDEMPOTENCY_KEY` constant.