### PR TITLE
NXPY-205: Improve S3 non-chunked uploads

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Changelog
 Release date: ``2021-xx-xx``
 
 - `NXPY-203 <https://jira.nuxeo.com/browse/NXPY-203>`__: Better support badly cased or unknown Portal SSO digest algorithms
+- `NXPY-205 <https://jira.nuxeo.com/browse/NXPY-205>`__: Improve S3 non-chunked uploads
 
 Technical changes
 -----------------

--- a/examples/blobs.rst
+++ b/examples/blobs.rst
@@ -141,6 +141,7 @@ For instance, you can use the Amazon provider with its S3 Direct Upload.
 
 .. code:: python
 
+    from nuxeo.constants import UP_AMAZON_S3
     from nuxeo.models import Document, FileBlob
 
     # Create a document
@@ -153,7 +154,7 @@ For instance, you can use the Amazon provider with its S3 Direct Upload.
     file = nuxeo.documents.create(new_file, parent_path="/default-domain/workspaces")
 
     # Create a batch using S3
-    batch = nuxeo.uploads.batch(handler="s3")
+    batch = nuxeo.uploads.batch(handler=UP_AMAZON_S3)
 
     # Create a blob
     blob = FileBlob("/path/to/file")

--- a/tests/test_batchupload.py
+++ b/tests/test_batchupload.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 import pytest
 
 from nuxeo.compat import text
-from nuxeo.constants import IDEMPOTENCY_KEY
+from nuxeo.constants import IDEMPOTENCY_KEY, UP_AMAZON_S3
 from nuxeo.exceptions import (
     CorruptedFile,
     HTTPError,
@@ -185,7 +185,7 @@ def test_handlers(server):
     assert isinstance(handlers, list)
     assert "default" in handlers
 
-    if "s3" in handlers:
+    if UP_AMAZON_S3 in handlers:
         assert server.uploads.has_s3()
     else:
         assert not server.uploads.has_s3()

--- a/tests/test_upload_s3.py
+++ b/tests/test_upload_s3.py
@@ -41,7 +41,7 @@ def bucket():
 @pytest.fixture
 def s3(aws_credentials, bucket):
     with mock_s3():
-        client = boto3.client("s3", region_name="eu-west-1")
+        client = boto3.client(UP_AMAZON_S3, region_name="eu-west-1")
 
         # Create a bucket
         client.create_bucket(
@@ -55,7 +55,7 @@ def s3(aws_credentials, bucket):
 @pytest.fixture
 def batch(aws_pwd, bucket, server):
     # TODO: when using a real server with S3 configured, just use:
-    #   obj = server.uploads.batch(handler="s3")
+    #   obj = server.uploads.batch(handler=UP_AMAZON_S3)
     obj = server.uploads.batch()
     obj.provider = UP_AMAZON_S3
     obj.extraInfo = {


### PR DESCRIPTION
The PR simply moves credential renewals to `ChunkUploaderS3` as it is useless to use that mechanism for non-chunked uploads.