### PR TITLE
NXPY-201: Allow null endpoints

### DIFF
--- a/examples/authentication.rst
+++ b/examples/authentication.rst
@@ -31,6 +31,14 @@ OAuth2
 
 OAuth2 with automatic credentials renewal is available by default.
 
+The ``OAuth2`` class can take several optionnal keyword arguments:
+
+- ``client_id``: the consumer client ID
+- ``client_secret``: the consumer client secret
+- ``token``: existent token
+- ``authorization_endpoint``: custom authorization endpoint
+- ``token_endpoint``: custom token endpoint
+
 Scenario 1: Generating a New Token
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/nuxeo/auth/oauth2.py
+++ b/nuxeo/auth/oauth2.py
@@ -24,6 +24,10 @@ except ImportError:
     pass
 
 
+DEFAULT_AUTHORIZATION_ENDPOINT = "oauth2/authorize"
+DEFAULT_TOKEN_ENDPOINT = "oauth2/token"
+
+
 class OAuth2(AuthBase):
     """OAuth2 mechanism."""
 
@@ -45,8 +49,8 @@ class OAuth2(AuthBase):
         client_secret=None,
         client_id=None,
         token=None,
-        authorization_endpoint="oauth2/authorize",
-        token_endpoint="oauth2/token",
+        authorization_endpoint=None,
+        token_endpoint=None,
     ):
         # type: (Text, Optional[Text], Optional[Text], Optional[Token], Optional[Text], Optional[Text]) -> None
         if not host.endswith("/"):
@@ -59,9 +63,11 @@ class OAuth2(AuthBase):
             self.set_token(token)
 
         # Allow to pass custom endpoints (not handled by the platform)
-        if not authorization_endpoint.startswith("https://"):
-            authorization_endpoint = self._host + authorization_endpoint
-        self._authorization_endpoint = authorization_endpoint
+        auth_endpoint = authorization_endpoint or DEFAULT_AUTHORIZATION_ENDPOINT
+        token_endpoint = token_endpoint or DEFAULT_TOKEN_ENDPOINT
+        if not auth_endpoint.startswith("https://"):
+            auth_endpoint = self._host + auth_endpoint
+        self._authorization_endpoint = auth_endpoint
         if not token_endpoint.startswith("https://"):
             token_endpoint = self._host + token_endpoint
         self._token_endpoint = token_endpoint


### PR DESCRIPTION
Allowing null endpoints will ease the Nuxeo Drive implementation
Default values are stored into constants and could be changed by implementations.