### PR TITLE
NXPY-201: Allow more extensability of request_token()

### DIFF
--- a/examples/authentication.rst
+++ b/examples/authentication.rst
@@ -62,7 +62,17 @@ Scenario 1: Generating a New Token
     authorization_response = req.url
 
     # Step 3, get the token
-    token = nuxeo.client.auth.request_token(authorization_response, code_verifier)
+    token = nuxeo.client.auth.request_token(
+        code_verifier=code_verifier,
+        authorization_response=authorization_response,
+    )
+
+    # Step 3, another possibility when you already parsed *authorization_response* and know the *code*
+    token = nuxeo.client.auth.request_token(
+        code_verifier=code_verifier,
+        code=code,
+        state=state,
+    )
 
 
 Scenario 2: Using an Existing Token

--- a/nuxeo/exceptions.py
+++ b/nuxeo/exceptions.py
@@ -124,14 +124,14 @@ class InvalidUploadHandler(NuxeoError):
 
 
 class OAuth2Error(HTTPError):
-    """ Exception thown when an OAuth2 error happens. """
+    """ Exception thrown when an OAuth2 error happens. """
 
     status = 400
 
-    def __init__(self, error, description):
-        # type: (Text, Text) -> None
-        self.stacktrace = error
-        self.message = description
+    def __init__(self, error):
+        # type: (Text) -> None
+        self.message = error
+        self.stacktrace = None
 
 
 class OngoingRequestError(Conflict):

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -52,11 +52,11 @@ def test_crafted_httperror_parse():
 
 
 def test_crafted_oauth2_error():
-    exc = OAuth2Error("invalid_grant", "Cannot refresh token")
+    exc = OAuth2Error("Cannot refresh token")
     assert str(exc)
     assert exc.status == 400
     assert exc.message == "Cannot refresh token"
-    assert exc.stacktrace == "invalid_grant"
+    assert not exc.stacktrace
 
 
 def test_crafted_ongoing_request_error():


### PR DESCRIPTION
Also simplified the `OAuth2Error` exception as the stacktrace was not useful.