### PR TITLE
NXPY-201: Move NuxeoClient._log_response() to utils.py::log_reponse()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Technical changes
 - Added nuxeo/auth/jwt.py
 - Added nuxeo/auth/oauth2.py
 - Added nuxeo/exceptions.py::\ ``OAuth2Error``
+- Added nuxeo/utils.py::\ ``log_response()``
 
 5.0.0
 -----

--- a/nuxeo/auth/oauth2.py
+++ b/nuxeo/auth/oauth2.py
@@ -10,6 +10,7 @@ from authlib.oauth2.rfc7636 import create_s256_code_challenge
 
 from ..compat import get_bytes
 from ..exceptions import OAuth2Error
+from ..utils import log_response
 from .base import AuthBase
 
 try:
@@ -57,6 +58,7 @@ class OAuth2(AuthBase):
             host += "/"
         self._host = host
         self._client = OAuth2Session(client_id=client_id, client_secret=client_secret)
+        self._client.session.hooks["response"] = [log_response]
         self._token_header = ""
         self.token = {}  # type: Token
         if token:


### PR DESCRIPTION
It is necessary to be able to log requests from the OAuthLib.