### PR TITLE
NXPY-230: Allow to pass requests arguments to the OAuth2 client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Release date: ``2021-0x-xx``
 
 - `NXPY-228 <https://jira.nuxeo.com/browse/NXPY-228>`__: Use proper job names in GitHub workflows
 - `NXPY-230 <https://jira.nuxeo.com/browse/NXPY-230>`__: Allow to pass requests arguments to the OAuth2 client
+- `NXPY-231 <https://jira.nuxeo.com/browse/NXPY-231>`__: Prevent warnings when packaging the module
 
 Technical changes
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,11 +7,12 @@ Changelog
 Release date: ``2021-0x-xx``
 
 - `NXPY-228 <https://jira.nuxeo.com/browse/NXPY-228>`__: Use proper job names in GitHub workflows
+- `NXPY-230 <https://jira.nuxeo.com/browse/NXPY-230>`__: Allow to pass requests arguments to the OAuth2 client
 
 Technical changes
 -----------------
 
--
+- Added ``subclient_kwargs`` keyword argument to ``OAuth2.__init__()``
 
 6.0.2
 -----

--- a/nuxeo/auth/oauth2.py
+++ b/nuxeo/auth/oauth2.py
@@ -45,6 +45,7 @@ class OAuth2(AuthBase):
         token_endpoint=None,  # type: Optional[str]
         redirect_uri=None,  # type: Optional[str]
         openid_configuration_url=None,  # type: Optional[str]
+        subclient_kwargs=None,  # Type: Optional[Dict[str, Any]]
     ):
         # type: (...) -> None
         if not host.endswith("/"):
@@ -59,11 +60,12 @@ class OAuth2(AuthBase):
         # Allow to pass custom endpoints
         if openid_configuration_url:
             # OpenID Connect Discovery
-            with requests.get(openid_configuration_url) as req:
+            subclient_kwargs = subclient_kwargs or {}
+            with requests.get(openid_configuration_url, **subclient_kwargs) as req:
                 self._openid_conf = req.json()
             auth_endpoint = self._openid_conf["authorization_endpoint"]
             token_endpoint = self._openid_conf["token_endpoint"]
-            with requests.get(self._openid_conf["jwks_uri"]) as req:
+            with requests.get(self._openid_conf["jwks_uri"], **subclient_kwargs) as req:
                 self._openid_conf["signing_keys"] = req.json()["keys"]
         else:
             auth_endpoint = authorization_endpoint or DEFAULT_AUTHORIZATION_ENDPOINT

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,11 +2,11 @@
 name = nuxeo
 version = 6.0.3
 author = Nuxeo
-author-email = maintainers-python@nuxeo.com
+author_email = maintainers-python@nuxeo.com
 description = Nuxeo REST API Python client
 long_description = file: README.rst
 url = https://github.com/nuxeo/nuxeo-python-client
-home-page = https://doc.nuxeo.com/nxdoc/python-client
+home_page = https://doc.nuxeo.com/nxdoc/python-client
 keywords = api, rest, automation, client, nuxeo, ecm
 license = Apache Software
 license_files =
@@ -74,4 +74,5 @@ exclude =
     .eggs
     .git
     .tox
+    venv
 inline-quotes = double


### PR DESCRIPTION
Also:
- NXPY-231: Prevent warnings when packaging the module