### PR TITLE
NXPY-256: Upgrade from node 16 to node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           path: dist/
           merge-multiple: true
       - run: ls -l dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: python-package-distributions*
+          pattern: python-package-distributions-*
           path: dist/
           merge-multiple: true
       - run: ls -l dist

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,6 @@ Minor changes
 - Upgraded `actions/upload-artifact` from 3 to 4
 - Upgraded `actions/setup-python` from 4 to 5
 - Upgraded `codecov/codecov-action` from 3.1.2 to 3.1.5
-- Upgraded `pypa/gh-action-pypi-publish` from master to release/v1
 
 6.1.1
 -----


### PR DESCRIPTION
Due to https://github.com/nuxeo/nuxeo-python-client/actions/runs/8735588141/job/23970902213 
Reverted pypa/gh-action-pypi-publish from release/v1 to master