### PR TITLE
NXPY-256: Upgrade from node 16 to node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           path: dist/
           merge-multiple: true
       - run: ls -l dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
           python-version: 3.9
       - run: python -m pip install -U pip setuptools wheel
       - run: python setup.py bdist_wheel
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
-          name: python-package-distributions-purebuilt
+          name: python-package-distributions
           path: ./dist/*.whl
 
   source-distribution:
@@ -37,9 +37,9 @@ jobs:
         with:
           python-version: 3.9
       - run: python setup.py sdist
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
-          name: python-package-distributions-source
+          name: python-package-distributions
           path: dist
 
   publish:
@@ -48,13 +48,12 @@ jobs:
       - source-distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
-          pattern: python-package-distributions-*
+          name: python-package-distributions
           path: dist/
-          merge-multiple: true
       - run: ls -l dist
-      - uses: pypa/gh-action-pypi-publish@master
+      - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: python-package-distributions*
+          pattern: python-package-distributions-*
           path: dist/
           merge-multiple: true
       - run: ls -l dist

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,10 +23,9 @@ Minor changes
 -----------------
 
 - Upgraded `actions/checkout` from 3 to 4
-- Upgraded `actions/download-artifact` from 3 to 4
-- Upgraded `actions/upload-artifact` from 3 to 4
 - Upgraded `actions/setup-python` from 4 to 5
 - Upgraded `codecov/codecov-action` from 3.1.2 to 3.1.5
+- Upgraded `pypa/gh-action-pypi-publish` from master to release/v1
 
 6.1.1
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,7 +27,6 @@ Minor changes
 - Upgraded `actions/upload-artifact` from 3 to 4
 - Upgraded `actions/setup-python` from 4 to 5
 - Upgraded `codecov/codecov-action` from 3.1.2 to 3.1.5
-- Upgraded `pypa/gh-action-pypi-publish` from master to release/v1
 
 6.1.1
 -----


### PR DESCRIPTION
Downgraded upload and download artifacts from 4 to 3 and Upgraded pypa/gh-action-pypi-publish from master to release/v1