### PR TITLE
NXPY-261: Deploy artifacts to pypi.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,10 @@ jobs:
         env:
           PYPI_API_REPO_URL: ${{ github.ref == 'refs/heads/master' && 'public' || 'private' }}
         with:
-          repository-url: "https://packages.nuxeo.com/repository/pypi-${{ env.PYPI_API_REPO_URL }}/"
-          user: ${{ secrets.PYPI_API_NUXEO_PACKAGE_USERNAME }}
-          password: ${{ secrets.PYPI_API_NUXEO_PACKAGE_TOKEN }}
+          # repository-url: "https://packages.nuxeo.com/repository/pypi-${{ env.PYPI_API_REPO_URL }}/"
+          # user: ${{ secrets.PYPI_API_NUXEO_PACKAGE_USERNAME }}
+          # password: ${{ secrets.PYPI_API_NUXEO_PACKAGE_TOKEN }}
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
           skip_existing: true
           verbose: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Release date: ``2024-05-02``
 - `NXPY-256 <https://jira.nuxeo.com/browse/NXPY-256>`__: Upgrade from Node 16 to 20
 - `NXPY-258 <https://jira.nuxeo.com/browse/NXPY-258>`__: File download from aws S3 with auto-redirect not working in case of OAuth
 - `NXPY-259 <https://jira.nuxeo.com/browse/NXPY-259>`__: Deploy artifacts to packages.nuxeo.com
+- `NXPY-261 <https://hyland.atlassian.net/browse/NXPY-261>`__: Deploy artifacts to pypi.org
 
 Technical changes
 -----------------


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Update deployment configuration to publish artifacts to pypi.org instead of the Nuxeo repository.