### PR TITLE
NXPY-261: Deploy artifacts to pypi.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,6 @@ jobs:
         env:
           PYPI_API_REPO_URL: ${{ github.ref == 'refs/heads/master' && 'public' || 'private' }}
         with:
-          # repository-url: "https://packages.nuxeo.com/repository/pypi-${{ env.PYPI_API_REPO_URL }}/"
-          # user: ${{ secrets.PYPI_API_NUXEO_PACKAGE_USERNAME }}
-          # password: ${{ secrets.PYPI_API_NUXEO_PACKAGE_TOKEN }}
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,5 +65,5 @@ jobs:
           # password: ${{ secrets.PYPI_API_NUXEO_PACKAGE_TOKEN }}
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-          skip_existing: true
+          skip-existing: true
           verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,10 @@ jobs:
         env:
           PYPI_API_REPO_URL: ${{ github.ref == 'refs/heads/master' && 'public' || 'private' }}
         with:
-          repository-url: "https://packages.nuxeo.com/repository/pypi-${{ env.PYPI_API_REPO_URL }}/"
-          user: ${{ secrets.PYPI_API_NUXEO_PACKAGE_USERNAME }}
-          password: ${{ secrets.PYPI_API_NUXEO_PACKAGE_TOKEN }}
+          # repository-url: "https://packages.nuxeo.com/repository/pypi-${{ env.PYPI_API_REPO_URL }}/"
+          # user: ${{ secrets.PYPI_API_NUXEO_PACKAGE_USERNAME }}
+          # password: ${{ secrets.PYPI_API_NUXEO_PACKAGE_TOKEN }}
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
           skip_existing: true
           verbose: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 Release date: ``2025-xx-xx``
 
-- `NXPY-261 <https://hyland.atlassian.net/browse/NXPY-261>`__: Deploy artifacts to pypi.org
+- `NXPY-261 <https://hyland.atlassian.net/browse/NXPY-261>`__: Deploy artifacts to PyPI.org
 - `NXPY-262 <https://hyland.atlassian.net/browse/NXPY-262>`__: Upgrade dependencies
 
 Technical changes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 Release date: ``2025-xx-xx``
 
+- `NXPY-261 <https://hyland.atlassian.net/browse/NXPY-261>`__: Deploy artifacts to pypi.org
 - `NXPY-262 <https://hyland.atlassian.net/browse/NXPY-262>`__: Upgrade dependencies
 
 Technical changes


### PR DESCRIPTION
## Summary by Sourcery

Deployment:
- Configures the release workflow to deploy artifacts to pypi.org instead of packages.nuxeo.com.