### PR TITLE
NXPY-272: Release Nuxeo Python Client 7.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,10 @@
 Changelog
 =========
 
-6.1.3
+7.0.0
 -----
 
-Release date: ``2026-xx-xx``
+Release date: ``2026-05-06``
 
 - `NXPY-261 <https://hyland.atlassian.net/browse/NXPY-261>`__: Deploy artifacts to PyPI.org
 - `NXPY-262 <https://hyland.atlassian.net/browse/NXPY-262>`__: Upgrade dependencies
@@ -14,6 +14,7 @@ Release date: ``2026-xx-xx``
 - `NXPY-268 <https://hyland.atlassian.net/browse/NXPY-268>`__: Enable dependabot version update
 - `NXPY-269 <https://hyland.atlassian.net/browse/NXPY-269>`__: Fix functional test
 - `NXPY-270 <https://hyland.atlassian.net/browse/NXPY-270>`__: Upgrade Python version
+- `NXPY-272 <https://hyland.atlassian.net/browse/NXPY-272>`__: Release Nuxeo Python Client 7.0.0
 - `NXPY-273 <https://hyland.atlassian.net/browse/NXPY-273>`__: Fix Docker Login Credentials
 
 Technical changes

--- a/nuxeo/__init__.py
+++ b/nuxeo/__init__.py
@@ -16,6 +16,7 @@ Contributors:
     Anindya Roy
     Pooja Ramkrishna Daine
     Sweta Yadav
+    Saptarshi Ghosh
     Shekhar Gupta
     and https://github.com/nuxeo/nuxeo-python-client/graphs/contributors
 """

--- a/nuxeo/__init__.py
+++ b/nuxeo/__init__.py
@@ -21,7 +21,7 @@ Contributors:
 """
 
 __author__ = "Nuxeo"
-__version__ = "6.1.2"
+__version__ = "7.0.0"
 __copyright__ = """
     Copyright Nuxeo (https://www.nuxeo.com) and others.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = nuxeo
-version = 6.1.2
+version = 7.0.0
 author = Nuxeo
 author_email = maintainers-python@nuxeo.com
 description = Nuxeo REST API Python client


### PR DESCRIPTION
## Summary by Sourcery

Update the changelog in preparation for the 7.0.0 release of the Nuxeo Python Client.