### PR TITLE
NXPY-275: fix setuptools issue in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.13.1 # Maximum supported version
+      - run: python -m pip install -U pip setuptools
       - run: python setup.py sdist
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Release date: ``2026-05-06``
 - `NXPY-272 <https://hyland.atlassian.net/browse/NXPY-272>`__: Release Nuxeo Python Client 7.0.0
 - `NXPY-273 <https://hyland.atlassian.net/browse/NXPY-273>`__: Fix Docker Login Credentials
 - `NXPY-274 <https://hyland.atlassian.net/browse/NXPY-274>`__: Update readme
+- `NXPY-275 <https://hyland.atlassian.net/browse/NXPY-275>`__: Fix setuptools issue in release workflow
 
 Technical changes
 -----------------


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the release GitHub Actions workflow to upgrade pip and setuptools before running the source distribution build.